### PR TITLE
Activate CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,7 +33,7 @@ jobs:
     docker:
       - image: circleci/node:12.16.0
     working_directory: ~/set-v2-strategies
-    parallelism: 3
+    parallelism: 2
     steps:
       - restore_cache:
           key: compiled-env-{{ .Environment.CIRCLE_SHA1 }}
@@ -72,7 +72,7 @@ jobs:
     # need to update the `persist_to_workspace` paths
     # in this job (below) as well as the list of files passed
     # to istanbul-combine in the `report_coverage` job
-    parallelism: 5
+    parallelism: 2
     steps:
       - restore_cache:
           key: compiled-env-{{ .Environment.CIRCLE_SHA1 }}
@@ -98,9 +98,6 @@ jobs:
           paths:
             - cov_0.json
             - cov_1.json
-            - cov_2.json
-            - cov_3.json
-            - cov_4.json
 
   report_coverage:
     docker:
@@ -117,10 +114,8 @@ jobs:
             cp -R /tmp/coverage/* .
             npx istanbul-combine-updated -r lcov \
               cov_0.json \
-              cov_1.json \
-              cov_2.json \
-              cov_3.json \
-              cov_4.json
+              cov_1.json
+
       - run:
           name: Upload coverage
           command: |

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 <p align="center">
   <a href="https://circleci.com/gh/SetProtocol/set-protocol-v2/tree/master">
-    <img src="https://img.shields.io/circleci/project/github/SetProtocol/set-protocol-v2/master.svg" />
+    <img src="https://img.shields.io/circleci/project/github/SetProtocol/set-v2-strategies/master.svg" />
   </a>
-  <a href='https://coveralls.io/github/SetProtocol/set-protocol-v2?branch=master'><img src='https://coveralls.io/repos/github/SetProtocol/set-protocol-v2/badge.svg?branch=master&amp;t=4pzROZ' alt='Coverage Status' /></a>
+  <a href='https://coveralls.io/github/SetProtocol/set-v2-strategies?branch=master'><img src='https://coveralls.io/repos/github/SetProtocol/set-v2-strategies/badge.svg?branch=master&amp;t=4pzROZ' alt='Coverage Status' /></a>
 </p>
 
 # Set Protocol V2 Contract Repository


### PR DESCRIPTION
Have turned on CI in CircleCI, Coveralls and added coveralls and alchemy tokens to the environment variables there. 

This PR:
+ Sets CI parallelism to 2 
+ Updates README badges for repo name

CI is failing because of TS compilation errors that should be resolved in #2 
