### PR TITLE
Add BaseManager (V1)

### DIFF
--- a/contracts/manager/BaseManager.sol
+++ b/contracts/manager/BaseManager.sol
@@ -1,0 +1,215 @@
+/*
+    Copyright 2021 Set Labs Inc.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+    SPDX-License-Identifier: Apache License, Version 2.0
+*/
+
+pragma solidity 0.6.10;
+
+import { Address } from "@openzeppelin/contracts/utils/Address.sol";
+
+import { AddressArrayUtils } from "../lib/AddressArrayUtils.sol";
+import { IAdapter } from "../interfaces/IAdapter.sol";
+import { ISetToken } from "../interfaces/ISetToken.sol";
+
+
+/**
+ * @title BaseManager
+ * @author Set Protocol
+ *
+ * Smart contract manager that contains permissions and admin functionality
+ */
+contract BaseManager {
+    using Address for address;
+    using AddressArrayUtils for address[];
+
+    /* ============ Events ============ */
+
+    event AdapterAdded(
+        address _adapter
+    );
+
+    event AdapterRemoved(
+        address _adapter
+    );
+
+    event MethodologistChanged(
+        address _oldMethodologist,
+        address _newMethodologist
+    );
+
+    event OperatorChanged(
+        address _oldOperator,
+        address _newOperator
+    );
+
+    /* ============ Modifiers ============ */
+
+    /**
+     * Throws if the sender is not the SetToken operator
+     */
+    modifier onlyOperator() {
+        require(msg.sender == operator, "Must be operator");
+        _;
+    }
+
+    /**
+     * Throws if the sender is not the SetToken methodologist
+     */
+    modifier onlyMethodologist() {
+        require(msg.sender == methodologist, "Must be methodologist");
+        _;
+    }
+
+    /**
+     * Throws if the sender is not a listed adapter
+     */
+    modifier onlyAdapter() {
+        require(isAdapter[msg.sender], "Must be adapter");
+        _;
+    }
+
+    /* ============ State Variables ============ */
+
+    // Instance of SetToken
+    ISetToken public setToken;
+
+    // Array of listed adapters
+    address[] internal adapters;
+
+    // Mapping to check if adapter is added
+    mapping(address => bool) public isAdapter;
+
+    // Address of operator which typically executes manager only functions on Set Protocol modules
+    address public operator;
+
+    // Address of methodologist which serves as providing methodology for the index
+    address public methodologist;
+
+    /* ============ Constructor ============ */
+
+    constructor(
+        ISetToken _setToken,
+        address _operator,
+        address _methodologist
+    )
+        public
+    {
+        setToken = _setToken;
+        operator = _operator;
+        methodologist = _methodologist;
+    }
+
+    /* ============ External Functions ============ */
+
+    /**
+     * MUTUAL UPGRADE: Update the SetToken manager address. Operator and Methodologist must each call
+     * this function to execute the update.
+     *
+     * @param _newManager           New manager address
+     */
+    function setManager(address _newManager) external onlyOperator {
+        require(_newManager != address(0), "Zero address not valid");
+        setToken.setManager(_newManager);
+    }
+
+    /**
+     * MUTUAL UPGRADE: Add a new adapter that the BaseManager can call.
+     *
+     * @param _adapter           New adapter to add
+     */
+    function addAdapter(address _adapter) external onlyOperator {
+        require(!isAdapter[_adapter], "Adapter already exists");
+        require(address(IAdapter(_adapter).manager()) == address(this), "Adapter manager invalid");
+
+        adapters.push(_adapter);
+
+        isAdapter[_adapter] = true;
+
+        emit AdapterAdded(_adapter);
+    }
+
+    /**
+     * MUTUAL UPGRADE: Remove an existing adapter tracked by the BaseManager.
+     *
+     * @param _adapter           Old adapter to remove
+     */
+    function removeAdapter(address _adapter) external onlyOperator {
+        require(isAdapter[_adapter], "Adapter does not exist");
+
+        adapters.removeStorage(_adapter);
+
+        isAdapter[_adapter] = false;
+
+        emit AdapterRemoved(_adapter);
+    }
+
+    /**
+     * ADAPTER ONLY: Interact with a module registered on the SetToken.
+     *
+     * @param _module           Module to interact with
+     * @param _data             Byte data of function to call in module
+     */
+    function interactManager(address _module, bytes calldata _data) external onlyAdapter {
+        // Invoke call to module, assume value will always be 0
+        _module.functionCallWithValue(_data, 0);
+    }
+
+    /**
+     * OPERATOR ONLY: Add a new module to the SetToken.
+     *
+     * @param _module           New module to add
+     */
+    function addModule(address _module) external onlyOperator {
+        setToken.addModule(_module);
+    }
+
+    /**
+     * OPERATOR ONLY: Remove a new module from the SetToken.
+     *
+     * @param _module           Module to remove
+     */
+    function removeModule(address _module) external onlyOperator {
+        setToken.removeModule(_module);
+    }
+
+    /**
+     * METHODOLOGIST ONLY: Update the methodologist address
+     *
+     * @param _newMethodologist           New methodologist address
+     */
+    function setMethodologist(address _newMethodologist) external onlyMethodologist {
+        emit MethodologistChanged(methodologist, _newMethodologist);
+
+        methodologist = _newMethodologist;
+    }
+
+    /**
+     * OPERATOR ONLY: Update the operator address
+     *
+     * @param _newOperator           New operator address
+     */
+    function setOperator(address _newOperator) external onlyOperator {
+        emit OperatorChanged(operator, _newOperator);
+
+        operator = _newOperator;
+    }
+
+    /* ============ External Getters ============ */
+
+    function getAdapters() external view returns(address[] memory) {
+        return adapters;
+    }
+}

--- a/test/manager/baseManager.spec.ts
+++ b/test/manager/baseManager.spec.ts
@@ -1,0 +1,445 @@
+import "module-alias/register";
+
+import { Address, Account, Bytes } from "@utils/types";
+import { ADDRESS_ZERO, ZERO } from "@utils/constants";
+import { BaseManager, BaseExtensionMock } from "@utils/contracts/index";
+import { SetToken } from "@setprotocol/set-protocol-v2/utils/contracts";
+import DeployHelper from "@utils/deploys";
+import {
+  addSnapshotBeforeRestoreAfterEach,
+  ether,
+  getAccounts,
+  getWaffleExpect,
+  getRandomAccount,
+  getRandomAddress
+} from "@utils/index";
+import { SystemFixture } from "@setprotocol/set-protocol-v2/utils/fixtures";
+import { getSystemFixture } from "@setprotocol/set-protocol-v2/utils/test";
+
+const expect = getWaffleExpect();
+
+describe("BaseManager", () => {
+  let owner: Account;
+  let methodologist: Account;
+  let otherAccount: Account;
+  let newManager: Account;
+  let setV2Setup: SystemFixture;
+
+  let deployer: DeployHelper;
+  let setToken: SetToken;
+
+  let baseManager: BaseManager;
+  let baseAdapter: BaseExtensionMock;
+
+  before(async () => {
+    [
+      owner,
+      otherAccount,
+      newManager,
+      methodologist,
+    ] = await getAccounts();
+
+    deployer = new DeployHelper(owner.wallet);
+
+    setV2Setup = getSystemFixture(owner.address);
+    await setV2Setup.initialize();
+
+    setToken = await setV2Setup.createSetToken(
+      [setV2Setup.dai.address],
+      [ether(1)],
+      [setV2Setup.issuanceModule.address, setV2Setup.streamingFeeModule.address]
+    );
+
+    // Initialize modules
+    await setV2Setup.issuanceModule.initialize(setToken.address, ADDRESS_ZERO);
+    const feeRecipient = owner.address;
+    const maxStreamingFeePercentage = ether(.1);
+    const streamingFeePercentage = ether(.02);
+    const streamingFeeSettings = {
+      feeRecipient,
+      maxStreamingFeePercentage,
+      streamingFeePercentage,
+      lastStreamingFeeTimestamp: ZERO,
+    };
+    await setV2Setup.streamingFeeModule.initialize(setToken.address, streamingFeeSettings);
+
+    // Deploy BaseManager
+    baseManager = await deployer.manager.deployBaseManager(
+      setToken.address,
+      owner.address,
+      methodologist.address,
+    );
+
+    // Transfer ownership to BaseManager
+    await setToken.setManager(baseManager.address);
+
+    baseAdapter = await deployer.mocks.deployBaseExtensionMock(baseManager.address);
+  });
+
+  addSnapshotBeforeRestoreAfterEach();
+
+  describe("#constructor", async () => {
+    let subjectSetToken: Address;
+    let subjectOperator: Address;
+    let subjectMethodologist: Address;
+
+    beforeEach(async () => {
+      subjectSetToken = setToken.address;
+      subjectOperator = owner.address;
+      subjectMethodologist = methodologist.address;
+    });
+
+    async function subject(): Promise<BaseManager> {
+      return await deployer.manager.deployBaseManager(
+        subjectSetToken,
+        subjectOperator,
+        subjectMethodologist,
+      );
+    }
+
+    it("should set the correct SetToken address", async () => {
+      const retrievedICManager = await subject();
+
+      const actualToken = await retrievedICManager.setToken();
+      expect (actualToken).to.eq(subjectSetToken);
+    });
+
+    it("should set the correct Operator address", async () => {
+      const retrievedICManager = await subject();
+
+      const actualOperator = await retrievedICManager.operator();
+      expect (actualOperator).to.eq(subjectOperator);
+    });
+
+    it("should set the correct Methodologist address", async () => {
+      const retrievedICManager = await subject();
+
+      const actualMethodologist = await retrievedICManager.methodologist();
+      expect (actualMethodologist).to.eq(subjectMethodologist);
+    });
+  });
+
+  describe("#setManager", async () => {
+    let subjectNewManager: Address;
+    let subjectCaller: Account;
+
+    beforeEach(async () => {
+      subjectNewManager = newManager.address;
+      subjectCaller = owner;
+    });
+
+    async function subject(): Promise<any> {
+      return baseManager.connect(subjectCaller.wallet).setManager(subjectNewManager);
+    }
+
+    it("should change the manager address", async () => {
+      await subject();
+      const manager = await setToken.manager();
+
+      expect(manager).to.eq(newManager.address);
+    });
+
+    describe("when passed manager is the zero address", async () => {
+      beforeEach(async () => {
+        subjectNewManager = ADDRESS_ZERO;
+      });
+
+      it("should revert", async () => {
+        await expect(subject()).to.be.revertedWith("Zero address not valid");
+      });
+    });
+
+    describe("when the caller is not the operator", async () => {
+      beforeEach(async () => {
+        subjectCaller = methodologist;
+      });
+
+      it("should revert", async () => {
+        await expect(subject()).to.be.revertedWith("Must be operator");
+      });
+    });
+  });
+
+  describe("#addAdapter", async () => {
+    let subjectAdapter: Address;
+    let subjectCaller: Account;
+
+    beforeEach(async () => {
+      subjectAdapter = baseAdapter.address;
+      subjectCaller = owner;
+    });
+
+    async function subject(): Promise<any> {
+      return baseManager.connect(subjectCaller.wallet).addAdapter(subjectAdapter);
+    }
+
+    it("should add the adapter address", async () => {
+      await subject();
+      const adapters = await baseManager.getAdapters();
+
+      expect(adapters[0]).to.eq(baseAdapter.address);
+    });
+
+    it("should set the adapter mapping", async () => {
+      await subject();
+      const isAdapter = await baseManager.isAdapter(subjectAdapter);
+
+      expect(isAdapter).to.be.true;
+    });
+
+    it("should emit the correct AdapterAdded event", async () => {
+      await expect(subject()).to.emit(baseManager, "AdapterAdded").withArgs(baseAdapter.address);
+    });
+
+    describe("when the adapter already exists", async () => {
+      beforeEach(async () => {
+        await subject();
+      });
+
+      it("should revert", async () => {
+        await expect(subject()).to.be.revertedWith("Adapter already exists");
+      });
+    });
+
+    describe("when adapter has different manager address", async () => {
+      beforeEach(async () => {
+        subjectAdapter = (await deployer.mocks.deployBaseExtensionMock(await getRandomAddress())).address;
+      });
+
+      it("should revert", async () => {
+        await expect(subject()).to.be.revertedWith("Adapter manager invalid");
+      });
+    });
+
+    describe("when the caller is not the operator", async () => {
+      beforeEach(async () => {
+        subjectCaller = methodologist;
+      });
+
+      it("should revert", async () => {
+        await expect(subject()).to.be.revertedWith("Must be operator");
+      });
+    });
+  });
+
+  describe("#removeAdapter", async () => {
+    let subjectAdapter: Address;
+    let subjectCaller: Account;
+
+    beforeEach(async () => {
+      await baseManager.connect(owner.wallet).addAdapter(baseAdapter.address);
+
+      subjectAdapter = baseAdapter.address;
+      subjectCaller = owner;
+    });
+
+    async function subject(): Promise<any> {
+      return baseManager.connect(subjectCaller.wallet).removeAdapter(subjectAdapter);
+    }
+
+    it("should remove the adapter address", async () => {
+      await subject();
+      const adapters = await baseManager.getAdapters();
+
+      expect(adapters.length).to.eq(0);
+    });
+
+    it("should set the adapter mapping", async () => {
+      await subject();
+      const isAdapter = await baseManager.isAdapter(subjectAdapter);
+
+      expect(isAdapter).to.be.false;
+    });
+
+    it("should emit the correct AdapterRemoved event", async () => {
+      await expect(subject()).to.emit(baseManager, "AdapterRemoved").withArgs(baseAdapter.address);
+    });
+
+    describe("when the adapter does not exist", async () => {
+      beforeEach(async () => {
+        subjectAdapter = await getRandomAddress();
+      });
+
+      it("should revert", async () => {
+        await expect(subject()).to.be.revertedWith("Adapter does not exist");
+      });
+    });
+
+    describe("when the caller is not the operator", async () => {
+      beforeEach(async () => {
+        subjectCaller = methodologist;
+      });
+
+      it("should revert", async () => {
+        await expect(subject()).to.be.revertedWith("Must be operator");
+      });
+    });
+  });
+
+  describe("#addModule", async () => {
+    let subjectModule: Address;
+    let subjectCaller: Account;
+
+    beforeEach(async () => {
+      await setV2Setup.controller.addModule(otherAccount.address);
+
+      subjectModule = otherAccount.address;
+      subjectCaller = owner;
+    });
+
+    async function subject(): Promise<any> {
+      return baseManager.connect(subjectCaller.wallet).addModule(subjectModule);
+    }
+
+    it("should add the module to the SetToken", async () => {
+      await subject();
+      const isModule = await setToken.isPendingModule(subjectModule);
+      expect(isModule).to.eq(true);
+    });
+
+    describe("when the caller is not the operator", async () => {
+      beforeEach(async () => {
+        subjectCaller = await getRandomAccount();
+      });
+
+      it("should revert", async () => {
+        await expect(subject()).to.be.revertedWith("Must be operator");
+      });
+    });
+  });
+
+  describe("#interactManager", async () => {
+    let subjectModule: Address;
+    let subjectCallData: Bytes;
+
+    beforeEach(async () => {
+      await baseManager.connect(owner.wallet).addAdapter(baseAdapter.address);
+
+      subjectModule = setV2Setup.streamingFeeModule.address;
+
+      // Invoke update fee recipient
+      subjectCallData = setV2Setup.streamingFeeModule.interface.encodeFunctionData("updateFeeRecipient", [
+        setToken.address,
+        otherAccount.address,
+      ]);
+    });
+
+    async function subject(): Promise<any> {
+      return baseAdapter.interactManager(subjectModule, subjectCallData);
+    }
+
+    it("should call updateFeeRecipient on the streaming fee module from the SetToken", async () => {
+      await subject();
+      const feeStates = await setV2Setup.streamingFeeModule.feeStates(setToken.address);
+      expect(feeStates.feeRecipient).to.eq(otherAccount.address);
+    });
+
+    describe("when the caller is not an adapter", async () => {
+      beforeEach(async () => {
+        await baseManager.connect(owner.wallet).removeAdapter(baseAdapter.address);
+      });
+
+      it("should revert", async () => {
+        await expect(subject()).to.be.revertedWith("Must be adapter");
+      });
+    });
+  });
+
+  describe("#removeModule", async () => {
+    let subjectModule: Address;
+    let subjectCaller: Account;
+
+    beforeEach(async () => {
+      subjectModule = setV2Setup.streamingFeeModule.address;
+      subjectCaller = owner;
+    });
+
+    async function subject(): Promise<any> {
+      return baseManager.connect(subjectCaller.wallet).removeModule(subjectModule);
+    }
+
+    it("should remove the module from the SetToken", async () => {
+      await subject();
+      const isModule = await setToken.isInitializedModule(subjectModule);
+      expect(isModule).to.eq(false);
+    });
+
+    describe("when the caller is not the operator", async () => {
+      beforeEach(async () => {
+        subjectCaller = await getRandomAccount();
+      });
+
+      it("should revert", async () => {
+        await expect(subject()).to.be.revertedWith("Must be operator");
+      });
+    });
+  });
+
+  describe("#setMethodologist", async () => {
+    let subjectNewMethodologist: Address;
+    let subjectCaller: Account;
+
+    beforeEach(async () => {
+      subjectNewMethodologist = await getRandomAddress();
+      subjectCaller = methodologist;
+    });
+
+    async function subject(): Promise<any> {
+      return baseManager.connect(subjectCaller.wallet).setMethodologist(subjectNewMethodologist);
+    }
+
+    it("should set the new methodologist", async () => {
+      await subject();
+      const actualIndexModule = await baseManager.methodologist();
+      expect(actualIndexModule).to.eq(subjectNewMethodologist);
+    });
+
+    it("should emit the correct MethodologistChanged event", async () => {
+      await expect(subject()).to.emit(baseManager, "MethodologistChanged").withArgs(methodologist.address, subjectNewMethodologist);
+    });
+
+    describe("when the caller is not the methodologist", async () => {
+      beforeEach(async () => {
+        subjectCaller = await getRandomAccount();
+      });
+
+      it("should revert", async () => {
+        await expect(subject()).to.be.revertedWith("Must be methodologist");
+      });
+    });
+  });
+
+  describe("#setOperator", async () => {
+    let subjectNewOperator: Address;
+    let subjectCaller: Account;
+
+    beforeEach(async () => {
+      subjectNewOperator = await getRandomAddress();
+      subjectCaller = owner;
+    });
+
+    async function subject(): Promise<any> {
+      return baseManager.connect(subjectCaller.wallet).setOperator(subjectNewOperator);
+    }
+
+    it("should set the new operator", async () => {
+      await subject();
+      const actualIndexModule = await baseManager.operator();
+      expect(actualIndexModule).to.eq(subjectNewOperator);
+    });
+
+    it("should emit the correct OperatorChanged event", async () => {
+      await expect(subject()).to.emit(baseManager, "OperatorChanged").withArgs(owner.address, subjectNewOperator);
+    });
+
+    describe("when the caller is not the operator", async () => {
+      beforeEach(async () => {
+        subjectCaller = await getRandomAccount();
+      });
+
+      it("should revert", async () => {
+        await expect(subject()).to.be.revertedWith("Must be operator");
+      });
+    });
+  });
+});

--- a/utils/contracts/index.ts
+++ b/utils/contracts/index.ts
@@ -1,5 +1,6 @@
 export { BaseExtensionMock } from "../../typechain/BaseExtensionMock";
 export { AddressArrayUtilsMock } from "../../typechain/AddressArrayUtilsMock";
+export { BaseManager } from "../..//typechain/BaseManager";
 export { BaseManagerV2 } from "../..//typechain/BaseManagerV2";
 export { ChainlinkAggregatorMock } from "../../typechain/ChainlinkAggregatorMock";
 export { MutualUpgradeMock } from "../../typechain/MutualUpgradeMock";

--- a/utils/deploys/deployManager.ts
+++ b/utils/deploys/deployManager.ts
@@ -1,6 +1,8 @@
 import { Signer } from "ethers";
 import { Address } from "../types";
-import { BaseManagerV2 } from "../contracts/index";
+import { BaseManager, BaseManagerV2 } from "../contracts/index";
+
+import { BaseManager__factory } from "../../typechain/factories/BaseManager__factory";
 import { BaseManagerV2__factory } from "../../typechain/factories/BaseManagerV2__factory";
 
 export default class DeployToken {
@@ -8,6 +10,18 @@ export default class DeployToken {
 
   constructor(deployerSigner: Signer) {
     this._deployerSigner = deployerSigner;
+  }
+
+  public async deployBaseManager(
+    set: Address,
+    operator: Address,
+    methodologist: Address
+  ): Promise<BaseManager> {
+    return await new BaseManager__factory(this._deployerSigner).deploy(
+      set,
+      operator,
+      methodologist
+    );
   }
 
   public async deployBaseManagerV2(


### PR DESCRIPTION
Ports BaseManager (v1) from index-coop-contracts per Richard's [proposal][1] in initial Perp strategy adapter review 

> [Suggest] replacing BaseManagerV2 with BaseManagerV1. Removes a ton of IC specific permissioning which simplifies a bunch of test setup

[1]: https://github.com/SetProtocol/set-v2-strategies/pull/2#pullrequestreview-841649474

