### PR TITLE
Delegated Manager System audit fixes and upgrades [SIM-55] [SIM-156]

### DIFF
--- a/contracts/factories/DelegatedManagerFactory.sol
+++ b/contracts/factories/DelegatedManagerFactory.sol
@@ -46,6 +46,7 @@ contract DelegatedManagerFactory {
     struct InitializeParams{
         address deployer;
         address owner;
+        address methodologist;
         IDelegatedManager manager;
         bool isPending;
     }
@@ -149,13 +150,12 @@ contract DelegatedManagerFactory {
 
         DelegatedManager manager = _deployManager(
             setToken,
-            _methodologist,
             _extensions,
             _operators,
             _assets
         );
 
-        _setInitializationState(setToken, address(manager), _owner);
+        _setInitializationState(setToken, address(manager), _owner, _methodologist);
 
         return (setToken, address(manager));
     }
@@ -195,13 +195,12 @@ contract DelegatedManagerFactory {
 
         DelegatedManager manager = _deployManager(
             _setToken,
-            _methodologist,
             _extensions,
             _operators,
             _assets
         );
 
-        _setInitializationState(_setToken, address(manager), _owner);
+        _setInitializationState(_setToken, address(manager), _owner, _methodologist);
 
         return address(manager);
     }
@@ -251,6 +250,7 @@ contract DelegatedManagerFactory {
         }
 
         manager.transferOwnership(initializeState[_setToken].owner);
+        manager.setMethodologist(initializeState[_setToken].methodologist);
 
         delete initializeState[_setToken];
 
@@ -297,7 +297,6 @@ contract DelegatedManagerFactory {
      * Deploys a DelegatedManager
      *
      * @param  _setToken         Instance of SetToken to migrate to the DelegatedManager system
-     * @param  _methodologist    Address to set as the DelegateManager's methodologist role
      * @param  _extensions       List of extensions authorized for the DelegateManager
      * @param  _operators        List of operators authorized for the DelegateManager
      * @param  _assets           List of assets DelegateManager can trade. When empty, asset allow list is not enforced
@@ -306,7 +305,6 @@ contract DelegatedManagerFactory {
      */
     function _deployManager(
         ISetToken _setToken,
-        address _methodologist,
         address[] memory _extensions,
         address[] memory _operators,
         address[] memory _assets
@@ -321,7 +319,7 @@ contract DelegatedManagerFactory {
         DelegatedManager newManager = new DelegatedManager(
             _setToken,
             address(this),
-            _methodologist,
+            address(this),
             _extensions,
             _operators,
             _assets,
@@ -347,15 +345,18 @@ contract DelegatedManagerFactory {
      * @param  _setToken         Instance of SetToken
      * @param  _manager          Address of DelegatedManager created for SetToken
      * @param  _owner            Address that will be given the `owner` DelegatedManager's role on initialization
+     * @param  _methodologist    Address that will be given the `methodologist` DelegatedManager's role on initialization
      */
     function _setInitializationState(
         ISetToken _setToken,
         address _manager,
-        address _owner
+        address _owner,
+        address _methodologist
     ) internal {
         initializeState[_setToken] = InitializeParams({
             deployer: msg.sender,
             owner: _owner,
+            methodologist: _methodologist,
             manager: IDelegatedManager(_manager),
             isPending: true
         });

--- a/contracts/factories/DelegatedManagerFactory.sol
+++ b/contracts/factories/DelegatedManagerFactory.sol
@@ -85,7 +85,7 @@ contract DelegatedManagerFactory {
     IController public immutable controller;
 
     // SetTokenFactory address
-    ISetTokenCreator public setTokenFactory;
+    ISetTokenCreator public immutable setTokenFactory;
 
     // Mapping which stores manager creation metadata between creation and initialization steps
     mapping(ISetToken=>InitializeParams) public initializeState;

--- a/contracts/interfaces/IDelegatedManager.sol
+++ b/contracts/interfaces/IDelegatedManager.sol
@@ -31,6 +31,8 @@ interface IDelegatedManager {
     function updateOwnerFeeSplit(uint256 _newFeeSplit) external;
 
     function updateOwnerFeeRecipient(address _newFeeRecipient) external;
+
+    function setMethodologist(address _newMethodologist) external;
     
     function transferOwnership(address _owner) external;
 

--- a/contracts/lib/BaseGlobalExtension.sol
+++ b/contracts/lib/BaseGlobalExtension.sol
@@ -44,9 +44,9 @@ abstract contract BaseGlobalExtension {
     /* ============ State Variables ============ */
 
     // Address of the ManagerCore
-    IManagerCore public managerCore;
+    IManagerCore public immutable managerCore;
 
-    // Mapping from Set Token to DelegatedManager 
+    // Mapping from Set Token to DelegatedManager
     mapping(ISetToken => IDelegatedManager) public setManagers;
 
     /* ============ Modifiers ============ */

--- a/contracts/lib/MutualUpgradeV2.sol
+++ b/contracts/lib/MutualUpgradeV2.sol
@@ -1,5 +1,5 @@
 /*
-    Copyright 2021 Set Labs Inc.
+    Copyright 2022 Set Labs Inc.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -22,7 +22,10 @@ pragma solidity 0.6.10;
  * @title MutualUpgradeV2
  * @author Set Protocol
  *
- * The MutualUpgrade contract contains a modifier for handling mutual upgrades between two parties
+ * The MutualUpgradeV2 contract contains a modifier for handling mutual upgrades between two parties
+ *
+ * CHANGELOG:
+ * - Update mutualUpgrade to allow single transaction execution if the two signing addresses are the same
  */
 contract MutualUpgradeV2 {
     /* ============ State Variables ============ */

--- a/contracts/lib/MutualUpgradeV2.sol
+++ b/contracts/lib/MutualUpgradeV2.sol
@@ -1,0 +1,79 @@
+/*
+    Copyright 2021 Set Labs Inc.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+    SPDX-License-Identifier: Apache License, Version 2.0
+*/
+
+pragma solidity 0.6.10;
+
+/**
+ * @title MutualUpgradeV2
+ * @author Set Protocol
+ *
+ * The MutualUpgrade contract contains a modifier for handling mutual upgrades between two parties
+ */
+contract MutualUpgradeV2 {
+    /* ============ State Variables ============ */
+
+    // Mapping of upgradable units and if upgrade has been initialized by other party
+    mapping(bytes32 => bool) public mutualUpgrades;
+
+    /* ============ Events ============ */
+
+    event MutualUpgradeRegistered(
+        bytes32 _upgradeHash
+    );
+
+    /* ============ Modifiers ============ */
+
+    modifier mutualUpgrade(address _signerOne, address _signerTwo) {
+        require(
+            msg.sender == _signerOne || msg.sender == _signerTwo,
+            "Must be authorized address"
+        );
+
+        // If the two signing addresses are the same, skip upgrade hash step
+        if (_signerOne == _signerTwo) {
+            _;
+        }
+
+        address nonCaller = _getNonCaller(_signerOne, _signerTwo);
+
+        // The upgrade hash is defined by the hash of the transaction call data and sender of msg,
+        // which uniquely identifies the function, arguments, and sender.
+        bytes32 expectedHash = keccak256(abi.encodePacked(msg.data, nonCaller));
+
+        if (!mutualUpgrades[expectedHash]) {
+            bytes32 newHash = keccak256(abi.encodePacked(msg.data, msg.sender));
+
+            mutualUpgrades[newHash] = true;
+
+            emit MutualUpgradeRegistered(newHash);
+
+            return;
+        }
+
+        delete mutualUpgrades[expectedHash];
+
+        // Run the rest of the upgrades
+        _;
+    }
+
+    /* ============ Internal Functions ============ */
+
+    function _getNonCaller(address _signerOne, address _signerTwo) internal view returns(address) {
+        return msg.sender == _signerOne ? _signerTwo : _signerOne;
+    }
+}

--- a/contracts/manager/DelegatedManager.sol
+++ b/contracts/manager/DelegatedManager.sol
@@ -28,6 +28,7 @@ import { PreciseUnitMath } from "@setprotocol/set-protocol-v2/contracts/lib/Prec
 
 import { AddressArrayUtils } from "../lib/AddressArrayUtils.sol";
 import { IGlobalExtension } from "../interfaces/IGlobalExtension.sol";
+import { MutualUpgradeV2 } from "../lib/MutualUpgradeV2.sol";
 
 
 /**
@@ -42,7 +43,7 @@ import { IGlobalExtension } from "../interfaces/IGlobalExtension.sol";
  * a part of the asset whitelist, hence they are a semi-trusted party. It is recommended that the owner address
  * be managed by a multi-sig or some form of permissioning system.
  */
-contract DelegatedManager is Ownable {
+contract DelegatedManager is Ownable, MutualUpgradeV2 {
     using Address for address;
     using AddressArrayUtils for address[];
     using SafeERC20 for IERC20;
@@ -327,7 +328,7 @@ contract DelegatedManager is Ownable {
      *
      * @param _newFeeSplit           Percent in precise units (100% = 10**18) of fees that accrue to owner
      */
-    function updateOwnerFeeSplit(uint256 _newFeeSplit) external onlyOwner {
+    function updateOwnerFeeSplit(uint256 _newFeeSplit) external mutualUpgrade(owner(), methodologist) {
         require(_newFeeSplit <= PreciseUnitMath.preciseUnit(), "Invalid fee split");
 
         ownerFeeSplit = _newFeeSplit;

--- a/contracts/manager/DelegatedManager.sol
+++ b/contracts/manager/DelegatedManager.sol
@@ -355,6 +355,8 @@ contract DelegatedManager is Ownable, MutualUpgradeV2 {
      * @param _newMethodologist           New methodologist address
      */
     function setMethodologist(address _newMethodologist) external onlyMethodologist {
+        require(_newMethodologist != address(0), "Null address passed");
+
         methodologist = _newMethodologist;
 
         emit MethodologistChanged(_newMethodologist);

--- a/contracts/mocks/MutualUpgradeV2Mock.sol
+++ b/contracts/mocks/MutualUpgradeV2Mock.sol
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: Apache License, Version 2.0
+pragma solidity 0.6.10;
+
+import { MutualUpgradeV2 } from "../lib/MutualUpgradeV2.sol";
+
+
+// Mock contract implementation of MutualUpgradeV2 functions
+contract MutualUpgradeV2Mock is
+    MutualUpgradeV2
+{
+    uint256 public testUint;
+    address public owner;
+    address public methodologist;
+
+    constructor(address _owner, address _methodologist) public {
+        owner = _owner;
+        methodologist = _methodologist;
+    }
+
+    function testMutualUpgrade(
+        uint256 _testUint
+    )
+        external
+        mutualUpgrade(owner, methodologist)
+    {
+        testUint = _testUint;
+    }
+}

--- a/test/extensions/issuanceExtension.spec.ts
+++ b/test/extensions/issuanceExtension.spec.ts
@@ -91,9 +91,10 @@ describe("IssuanceExtension", () => {
     );
 
     ownerFeeSplit = ether(0.1);
-    await delegatedManager.updateOwnerFeeSplit(ownerFeeSplit);
+    await delegatedManager.connect(owner.wallet).updateOwnerFeeSplit(ownerFeeSplit);
+    await delegatedManager.connect(methodologist.wallet).updateOwnerFeeSplit(ownerFeeSplit);
     ownerFeeRecipient = owner.address;
-    await delegatedManager.updateOwnerFeeRecipient(ownerFeeRecipient);
+    await delegatedManager.connect(owner.wallet).updateOwnerFeeRecipient(ownerFeeRecipient);
 
     await setToken.setManager(delegatedManager.address);
 
@@ -695,6 +696,7 @@ describe("IssuanceExtension", () => {
     describe("when methodologist fees are 0", async () => {
       beforeEach(async () => {
         await delegatedManager.connect(owner.wallet).updateOwnerFeeSplit(ether(1));
+        await delegatedManager.connect(methodologist.wallet).updateOwnerFeeSplit(ether(1));
       });
 
       it("should not send fees to methodologist", async () => {
@@ -710,6 +712,7 @@ describe("IssuanceExtension", () => {
     describe("when owner fees are 0", async () => {
       beforeEach(async () => {
         await delegatedManager.connect(owner.wallet).updateOwnerFeeSplit(ZERO);
+        await delegatedManager.connect(methodologist.wallet).updateOwnerFeeSplit(ZERO);
       });
 
       it("should not send fees to owner fee recipient", async () => {

--- a/test/extensions/streamingFeeSplitExtension.spec.ts
+++ b/test/extensions/streamingFeeSplitExtension.spec.ts
@@ -95,9 +95,10 @@ describe("StreamingFeeSplitExtension", () => {
     );
 
     ownerFeeSplit = ether(0.1);
-    await delegatedManager.updateOwnerFeeSplit(ownerFeeSplit);
+    await delegatedManager.connect(owner.wallet).updateOwnerFeeSplit(ownerFeeSplit);
+    await delegatedManager.connect(methodologist.wallet).updateOwnerFeeSplit(ownerFeeSplit);
     ownerFeeRecipient = owner.address;
-    await delegatedManager.updateOwnerFeeRecipient(ownerFeeRecipient);
+    await delegatedManager.connect(owner.wallet).updateOwnerFeeRecipient(ownerFeeRecipient);
 
     await setToken.setManager(delegatedManager.address);
 
@@ -630,6 +631,7 @@ describe("StreamingFeeSplitExtension", () => {
     describe("when methodologist fees are 0", async () => {
       beforeEach(async () => {
         await delegatedManager.connect(owner.wallet).updateOwnerFeeSplit(ether(1));
+        await delegatedManager.connect(methodologist.wallet).updateOwnerFeeSplit(ether(1));
       });
 
       it("should not send fees to methodologist", async () => {
@@ -645,6 +647,7 @@ describe("StreamingFeeSplitExtension", () => {
     describe("when owner fees are 0", async () => {
       beforeEach(async () => {
         await delegatedManager.connect(owner.wallet).updateOwnerFeeSplit(ZERO);
+        await delegatedManager.connect(methodologist.wallet).updateOwnerFeeSplit(ZERO);
       });
 
       it("should not send fees to owner fee recipient", async () => {

--- a/test/factories/delegatedManagerFactory.spec.ts
+++ b/test/factories/delegatedManagerFactory.spec.ts
@@ -223,7 +223,7 @@ describe("DelegatedManagerFactory", () => {
 
       expect(await delegatedManager.setToken()).eq(setTokenAddress);
       expect(await delegatedManager.factory()).eq(delegatedManagerFactory.address);
-      expect(await delegatedManager.methodologist()).eq(subjectMethodologist);
+      expect(await delegatedManager.methodologist()).eq(delegatedManagerFactory.address);
       expect(await delegatedManager.useAssetAllowlist()).eq(true);
     });
 
@@ -259,6 +259,7 @@ describe("DelegatedManagerFactory", () => {
 
       expect(initializeParams.deployer).eq(owner.address);
       expect(initializeParams.owner).eq(subjectOwner);
+      expect(initializeParams.methodologist).eq(subjectMethodologist);
       expect(initializeParams.isPending).eq(true);
       expect(initializeParams.manager).eq(createdContracts[1]);
     });
@@ -412,7 +413,7 @@ describe("DelegatedManagerFactory", () => {
 
       expect(await delegatedManager.setToken()).eq(subjectSetToken);
       expect(await delegatedManager.factory()).eq(delegatedManagerFactory.address);
-      expect(await delegatedManager.methodologist()).eq(subjectMethodologist);
+      expect(await delegatedManager.methodologist()).eq(delegatedManagerFactory.address);
       expect(await delegatedManager.useAssetAllowlist()).eq(true);
     });
 
@@ -432,6 +433,7 @@ describe("DelegatedManagerFactory", () => {
 
       expect(initializeParams.deployer).eq(owner.address);
       expect(initializeParams.owner).eq(subjectOwner);
+      expect(initializeParams.methodologist).eq(subjectMethodologist);
       expect(initializeParams.isPending).eq(true);
       expect(initializeParams.manager).eq(newManagerAddress);
     });
@@ -626,6 +628,17 @@ describe("DelegatedManagerFactory", () => {
         expect(newOwner).eq(initializeParams.owner);
       });
 
+      it("should transfer the methodologist role of DelegatedManager to the `methodologist` specified initializeState", async () => {
+        const oldMethodologist = await manager.methodologist();
+
+        await subject();
+
+        const newMethodologist = await manager.methodologist();
+
+        expect(oldMethodologist).not.eq(newMethodologist);
+        expect(newMethodologist).eq(initializeParams.methodologist);
+      });
+
       it("should delete the initializeState for the SetToken", async () => {
         await subject();
 
@@ -633,6 +646,7 @@ describe("DelegatedManagerFactory", () => {
 
         expect(finalInitializeParams.deployer).eq(ADDRESS_ZERO);
         expect(finalInitializeParams.owner).eq(ADDRESS_ZERO);
+        expect(finalInitializeParams.methodologist).eq(ADDRESS_ZERO);
         expect(finalInitializeParams.manager).eq(ADDRESS_ZERO);
         expect(finalInitializeParams.isPending).eq(false);
       });
@@ -726,6 +740,17 @@ describe("DelegatedManagerFactory", () => {
         expect(newOwner).eq(initializeParams.owner);
       });
 
+      it("should transfer the methodologist role of DelegatedManager to the `methodologist` specified initializeState", async () => {
+        const oldMethodologist = await manager.methodologist();
+
+        await subject();
+
+        const newMethodologist = await manager.methodologist();
+
+        expect(oldMethodologist).not.eq(newMethodologist);
+        expect(newMethodologist).eq(initializeParams.methodologist);
+      });
+
       it("should delete the initializeState for the SetToken", async () => {
         await subject();
 
@@ -733,6 +758,7 @@ describe("DelegatedManagerFactory", () => {
 
         expect(finalInitializeParams.deployer).eq(ADDRESS_ZERO);
         expect(finalInitializeParams.owner).eq(ADDRESS_ZERO);
+        expect(finalInitializeParams.methodologist).eq(ADDRESS_ZERO);
         expect(finalInitializeParams.manager).eq(ADDRESS_ZERO);
         expect(finalInitializeParams.isPending).eq(false);
       });

--- a/test/lib/mutualUpgradeV2.spec.ts
+++ b/test/lib/mutualUpgradeV2.spec.ts
@@ -1,0 +1,148 @@
+import "module-alias/register";
+import { solidityKeccak256 } from "ethers/lib/utils";
+import { BigNumber } from "ethers";
+
+import { Account } from "@utils/types";
+import { ONE, ZERO } from "@utils/constants";
+import { MutualUpgradeV2Mock } from "@utils/contracts/index";
+import DeployHelper from "@utils/deploys";
+import {
+  addSnapshotBeforeRestoreAfterEach,
+  getAccounts,
+  getWaffleExpect,
+  getRandomAccount,
+} from "@utils/index";
+import { ContractTransaction } from "ethers";
+
+const expect = getWaffleExpect();
+
+describe("MutualUpgradeV2", () => {
+  let owner: Account;
+  let methodologist: Account;
+  let deployer: DeployHelper;
+
+  let mutualUpgradeV2Mock: MutualUpgradeV2Mock;
+
+  before(async () => {
+    [
+      owner,
+      methodologist,
+    ] = await getAccounts();
+
+    deployer = new DeployHelper(owner.wallet);
+
+    mutualUpgradeV2Mock = await deployer.mocks.deployMutualUpgradeV2Mock(owner.address, methodologist.address);
+  });
+
+  addSnapshotBeforeRestoreAfterEach();
+
+  describe("#testMutualUpgradeV2", async () => {
+    let subjectTestUint: BigNumber;
+    let subjectCaller: Account;
+    let subjectMutualUpgradeV2Mock: MutualUpgradeV2Mock;
+
+    beforeEach(async () => {
+      subjectTestUint = ONE;
+      subjectCaller = owner;
+      subjectMutualUpgradeV2Mock = mutualUpgradeV2Mock;
+    });
+
+    async function subject(): Promise<ContractTransaction> {
+      return subjectMutualUpgradeV2Mock.connect(subjectCaller.wallet).testMutualUpgrade(subjectTestUint);
+    }
+
+    describe("when the two mutual upgrade parties are the same", async () => {
+      let trivialMutualUpgradeV2Mock: MutualUpgradeV2Mock;
+
+      beforeEach(async () => {
+        trivialMutualUpgradeV2Mock = await deployer.mocks.deployMutualUpgradeV2Mock(owner.address, owner.address);
+
+        subjectMutualUpgradeV2Mock = trivialMutualUpgradeV2Mock;
+      });
+
+      it("should update the testUint", async () => {
+        await subject();
+
+        const currentTestUint = await trivialMutualUpgradeV2Mock.testUint();
+        expect(currentTestUint).to.eq(subjectTestUint);
+      });
+    });
+
+    describe("when the mutualUpgrade hash is not set", async () => {
+      it("should register the initial mutual upgrade", async () => {
+        const txHash = await subject();
+
+        const expectedHash = solidityKeccak256(["bytes", "address"], [txHash.data, subjectCaller.address]);
+        const isLogged = await mutualUpgradeV2Mock.mutualUpgrades(expectedHash);
+
+        expect(isLogged).to.be.true;
+      });
+
+      it("should not update the testUint", async () => {
+        await subject();
+
+        const currentInt = await mutualUpgradeV2Mock.testUint();
+        expect(currentInt).to.eq(ZERO);
+      });
+
+      it("emits a MutualUpgradeRegistered event", async () => {
+        await expect(subject()).to.emit(mutualUpgradeV2Mock, "MutualUpgradeRegistered");
+      });
+    });
+
+    describe("when the mutualUpgrade hash is set", async () => {
+      beforeEach(async () => {
+        await subject();
+        subjectCaller = methodologist;
+      });
+
+      it("should clear the mutualUpgrade hash", async () => {
+        const txHash = await subject();
+
+        const expectedHash = solidityKeccak256(["bytes", "address"], [txHash.data, subjectCaller.address]);
+        const isLogged = await mutualUpgradeV2Mock.mutualUpgrades(expectedHash);
+
+        expect(isLogged).to.be.false;
+      });
+
+      it("should update the testUint", async () => {
+        await subject();
+
+        const currentTestUint = await mutualUpgradeV2Mock.testUint();
+        expect(currentTestUint).to.eq(subjectTestUint);
+      });
+
+      describe("when the same address calls it twice", async () => {
+        beforeEach(async () => {
+          subjectCaller = owner;
+        });
+
+        it("should stay logged", async () => {
+          const txHash = await subject();
+
+          const expectedHash = solidityKeccak256(["bytes", "address"], [txHash.data, subjectCaller.address]);
+          const isLogged = await mutualUpgradeV2Mock.mutualUpgrades(expectedHash);
+
+          expect(isLogged).to.be.true;
+        });
+
+        it("should not change the integer value", async () => {
+          await subject();
+
+          const currentInt = await mutualUpgradeV2Mock.testUint();
+          expect(currentInt).to.eq(ZERO);
+        });
+      });
+    });
+
+    describe("when the sender is not one of the allowed addresses", async () => {
+      beforeEach(async () => {
+        subjectCaller = await getRandomAccount();
+      });
+
+      it("should revert", async () => {
+        await expect(subject()).to.be.revertedWith("Must be authorized address");
+      });
+    });
+  });
+});

--- a/test/manager/delegatedManager.spec.ts
+++ b/test/manager/delegatedManager.spec.ts
@@ -799,6 +799,14 @@ describe("DelegatedManager", () => {
 
         expect(isLogged).to.be.true;
       });
+
+      it("should not update fee split", async () => {
+        await subject(subjectOwnerCaller);
+
+        const feeSplit =  await delegatedManager.ownerFeeSplit();
+
+        expect(feeSplit).to.eq(ZERO);
+      });
     });
 
     describe("when the caller is not the owner or methodologist", async () => {

--- a/test/manager/delegatedManager.spec.ts
+++ b/test/manager/delegatedManager.spec.ts
@@ -744,6 +744,16 @@ describe("DelegatedManager", () => {
         await expect(subject()).to.be.revertedWith("Must be methodologist");
       });
     });
+
+    describe("when passed methodologist is the zero address", async () => {
+      beforeEach(async () => {
+        subjectNewMethodologist = ADDRESS_ZERO;
+      });
+
+      it("should revert", async () => {
+        await expect(subject()).to.be.revertedWith("Null address passed");
+      });
+    });
   });
 
   describe("#updateOwnerFeeSplit", async () => {

--- a/test/managerCore.spec.ts
+++ b/test/managerCore.spec.ts
@@ -45,6 +45,7 @@ describe("ManagerCore", () => {
 
     delegatedManagerFactory = await deployer.factories.deployDelegatedManagerFactory(
       managerCore.address,
+      setV2Setup.controller.address,
       setV2Setup.factory.address
     );
   });

--- a/utils/contracts/index.ts
+++ b/utils/contracts/index.ts
@@ -8,6 +8,7 @@ export { DelegatedManagerFactory } from "../../typechain/DelegatedManagerFactory
 export { ManagerCore } from "../../typechain/ManagerCore";
 export { ManagerMock } from "../../typechain/ManagerMock";
 export { MutualUpgradeMock } from "../../typechain/MutualUpgradeMock";
+export { MutualUpgradeV2Mock } from "../../typechain/MutualUpgradeV2Mock";
 export { PerpV2LeverageStrategyExtension } from "../../typechain/PerpV2LeverageStrategyExtension";
 export { FeeSplitExtension } from "../../typechain/FeeSplitExtension";
 export { PerpV2PriceFeedMock } from "../../typechain/PerpV2PriceFeedMock";

--- a/utils/deploys/deployFactories.ts
+++ b/utils/deploys/deployFactories.ts
@@ -15,8 +15,13 @@ export default class DeployFactories {
 
   public async deployDelegatedManagerFactory(
     managerCore: Address,
+    controller: Address,
     setTokenFactory: Address
   ): Promise<DelegatedManagerFactory> {
-    return await new DelegatedManagerFactory__factory(this._deployerSigner).deploy(managerCore, setTokenFactory);
+    return await new DelegatedManagerFactory__factory(this._deployerSigner).deploy(
+      managerCore,
+      controller,
+      setTokenFactory
+    );
   }
 }

--- a/utils/deploys/deployMocks.ts
+++ b/utils/deploys/deployMocks.ts
@@ -23,6 +23,7 @@ import { ManagerMock__factory } from "../../typechain/factories/ManagerMock__fac
 import { ChainlinkAggregatorMock__factory  } from "@setprotocol/set-protocol-v2/typechain";
 import { ContractCallerMock__factory } from "@setprotocol/set-protocol-v2/typechain";
 import { MutualUpgradeMock__factory } from "../../typechain/factories/MutualUpgradeMock__factory";
+import { MutualUpgradeV2Mock__factory } from "../../typechain/factories/MutualUpgradeV2Mock__factory";
 import { PerpV2PriceFeedMock__factory } from "../../typechain/factories/PerpV2PriceFeedMock__factory";
 import { StandardTokenMock__factory  } from "../../typechain/factories/StandardTokenMock__factory";
 import { StringArrayUtilsMock__factory  } from "../../typechain/factories/StringArrayUtilsMock__factory";
@@ -52,6 +53,10 @@ export default class DeployMocks {
 
   public async deployMutualUpgradeMock(owner: Address, methodologist: string): Promise<MutualUpgradeMock> {
     return await new MutualUpgradeMock__factory(this._deployerSigner).deploy(owner, methodologist);
+  }
+
+  public async deployMutualUpgradeV2Mock(owner: Address, methodologist: string): Promise<MutualUpgradeMock> {
+    return await new MutualUpgradeV2Mock__factory(this._deployerSigner).deploy(owner, methodologist);
   }
 
   public async deployStandardTokenMock(owner: Address, decimals: number): Promise<StandardTokenMock> {


### PR DESCRIPTION
Audit Fixes

[5.3] Potential grief through arbitrary contract call
- Add `controller` to DelegatedManagerFactory. 
    -  In `createManager()`, require that the incoming `_setToken` is valid on the `controller`
    - In `initialize()`, require that the incoming `_initializeTargets` does not include a `controller` tracked `setToken`

[5.4.1] Design Comments
- On DelegatedManagerFactory, make `setTokenFactory` immutable
- On BaseGlobalExtension, make `managerCore` immutable
- On DelegatedManager, add address zero check to `setMethodologist()`

Upgrades
- On DelegatedManager, add mutual upgrade between the `owner` and `methodologist` to `updateOwnerFeeSplit()`