### PR TITLE
Delegated Manager System internal audit fixes [SIM-179]

### DIFF
--- a/contracts/ManagerCore.sol
+++ b/contracts/ManagerCore.sol
@@ -99,11 +99,13 @@ contract ManagerCore is Ownable {
             address extension = _extensions[i];
             require(extension != address(0), "Zero address submitted.");
             isExtension[extension] = true;
+            emit ExtensionAdded(extension);
         }
         for (uint256 i = 0; i < _factories.length; i++) {
             address factory = _factories[i];
             require(factory != address(0), "Zero address submitted.");
             isFactory[factory] = true;
+            emit FactoryAdded(factory);
         }
 
         // Set to true to only allow initialization once

--- a/contracts/ManagerCore.sol
+++ b/contracts/ManagerCore.sol
@@ -96,16 +96,10 @@ contract ManagerCore is Ownable {
 
         // Loop through and initialize isExtension and isFactory mapping
         for (uint256 i = 0; i < _extensions.length; i++) {
-            address extension = _extensions[i];
-            require(extension != address(0), "Zero address submitted.");
-            isExtension[extension] = true;
-            emit ExtensionAdded(extension);
+            _addExtension(_extensions[i]);
         }
         for (uint256 i = 0; i < _factories.length; i++) {
-            address factory = _factories[i];
-            require(factory != address(0), "Zero address submitted.");
-            isFactory[factory] = true;
-            emit FactoryAdded(factory);
+            _addFactory(_factories[i]);
         }
 
         // Set to true to only allow initialization once
@@ -120,11 +114,9 @@ contract ManagerCore is Ownable {
     function addExtension(address _extension) external onlyInitialized onlyOwner {
         require(!isExtension[_extension], "Extension already exists");
 
-        isExtension[_extension] = true;
+        _addExtension(_extension);
 
         extensions.push(_extension);
-
-        emit ExtensionAdded(_extension);
     }
 
     /**
@@ -150,11 +142,9 @@ contract ManagerCore is Ownable {
     function addFactory(address _factory) external onlyInitialized onlyOwner {
         require(!isFactory[_factory], "Factory already exists");
 
-        isFactory[_factory] = true;
+        _addFactory(_factory);
 
         factories.push(_factory);
-
-        emit FactoryAdded(_factory);
     }
 
     /**
@@ -178,6 +168,7 @@ contract ManagerCore is Ownable {
      * @param _manager               Address of the manager contract to add
      */
     function addManager(address _manager) external onlyInitialized onlyFactory {
+        require(_manager != address(0), "Zero address submitted.");
         require(!isManager[_manager], "Manager already exists");
 
         isManager[_manager] = true;
@@ -214,5 +205,33 @@ contract ManagerCore is Ownable {
 
     function getManagers() external view returns (address[] memory) {
         return managers;
+    }
+
+    /* ============ Internal Functions ============ */
+
+    /**
+     * Add an extension tracked on the ManagerCore
+     *
+     * @param _extension               Address of the extension contract to add
+     */
+    function _addExtension(address _extension) internal {
+        require(_extension != address(0), "Zero address submitted.");
+
+        isExtension[_extension] = true;
+
+        emit ExtensionAdded(_extension);
+    }
+
+    /**
+     * Add a factory tracked on the ManagerCore
+     *
+     * @param _factory               Address of the factory contract to add
+     */
+    function _addFactory(address _factory) internal {
+        require(_factory != address(0), "Zero address submitted.");
+
+        isFactory[_factory] = true;
+
+        emit FactoryAdded(_factory);
     }
 }

--- a/contracts/ManagerCore.sol
+++ b/contracts/ManagerCore.sol
@@ -79,9 +79,11 @@ contract ManagerCore is Ownable {
      * Initializes any predeployed factories. Note: This function can only be called by
      * the owner once to batch initialize the initial system contracts.
      *
+     * @param _extensions            List of extensions to add
      * @param _factories             List of factories to add
      */
     function initialize(
+        address[] memory _extensions,
         address[] memory _factories
     )
         external
@@ -89,9 +91,15 @@ contract ManagerCore is Ownable {
     {
         require(!isInitialized, "ManagerCore is already initialized");
 
+        extensions = _extensions;
         factories = _factories;
 
-        // Loop through and initialize isFactory mapping
+        // Loop through and initialize isExtension and isFactory mapping
+        for (uint256 i = 0; i < _extensions.length; i++) {
+            address extension = _extensions[i];
+            require(extension != address(0), "Zero address submitted.");
+            isExtension[extension] = true;
+        }
         for (uint256 i = 0; i < _factories.length; i++) {
             address factory = _factories[i];
             require(factory != address(0), "Zero address submitted.");

--- a/contracts/ManagerCore.sol
+++ b/contracts/ManagerCore.sol
@@ -168,7 +168,6 @@ contract ManagerCore is Ownable {
      * @param _manager               Address of the manager contract to add
      */
     function addManager(address _manager) external onlyInitialized onlyFactory {
-        require(_manager != address(0), "Zero address submitted.");
         require(!isManager[_manager], "Manager already exists");
 
         isManager[_manager] = true;

--- a/contracts/extensions/TradeExtension.sol
+++ b/contracts/extensions/TradeExtension.sol
@@ -99,10 +99,13 @@ contract TradeExtension is BaseGlobalExtension {
     }
 
     /**
-     * ONLY MANAGER: Remove an existing SetToken and DelegatedManager tracked by the TradeExtension 
+     * ONLY MANAGER: Remove an existing SetToken and DelegatedManager tracked by the TradeExtension
      */
     function removeExtension() external override {
-        _removeExtension();
+        IDelegatedManager delegatedManager = IDelegatedManager(msg.sender);
+        ISetToken setToken = delegatedManager.setToken();
+
+        _removeExtension(setToken, delegatedManager);
     }
 
     /**
@@ -132,7 +135,7 @@ contract TradeExtension is BaseGlobalExtension {
         onlyAllowedAsset(_setToken, _receiveToken)
     {
         bytes memory callData = abi.encodeWithSignature(
-            "trade(address,string,address,uint256,address,uint256,bytes)", 
+            "trade(address,string,address,uint256,address,uint256,bytes)",
             _setToken,
             _exchangeName,
             _sendToken,

--- a/contracts/factories/DelegatedManagerFactory.sol
+++ b/contracts/factories/DelegatedManagerFactory.sol
@@ -29,8 +29,6 @@ import { IDelegatedManager } from "../interfaces/IDelegatedManager.sol";
 import { IManagerCore } from "../interfaces/IManagerCore.sol";
 import { ISetTokenCreator } from "../interfaces/ISetTokenCreator.sol";
 
-import "hardhat/console.sol";
-
 /**
  * @title DelegatedManagerFactory
  * @author Set Protocol

--- a/contracts/factories/DelegatedManagerFactory.sol
+++ b/contracts/factories/DelegatedManagerFactory.sol
@@ -231,7 +231,7 @@ contract DelegatedManagerFactory {
         uint256 _ownerFeeSplit,
         address _ownerFeeRecipient,
         address[] memory _extensions,
-        bytes[] memory _initializeBytecode
+        bytes[] calldata _initializeBytecode
     )
         external
     {
@@ -251,9 +251,20 @@ contract DelegatedManagerFactory {
             address extension = _extensions[i];
             require(managerCore.isExtension(extension), "Target must be ManagerCore-enabled Extension");
 
+            bytes calldata initializeBytecode = _initializeBytecode[i];
+
+            address inputManager = abi.decode(initializeBytecode[4:37], (address));
+            require(inputManager == address(manager), "Must target correct DelegatedManager");
+
+            // address firstArg;
+            // assembly {
+            //     firstArg := mload(add(initializeBytecode, 4))
+            // }
+            // require(firstArg == address(manager), "Must target correct DelegatedManager");
+
             // Because we validate uniqueness of _extensions only one transaction can be sent to each extension during this
             // transaction. Due to this no extension can be used for any SetToken transactions other than initializing these contracts
-            extension.functionCallWithValue(_initializeBytecode[i], 0);
+            extension.functionCallWithValue(initializeBytecode, 0);
         }
 
         _setManagerState(

--- a/contracts/factories/DelegatedManagerFactory.sol
+++ b/contracts/factories/DelegatedManagerFactory.sol
@@ -253,7 +253,7 @@ contract DelegatedManagerFactory {
 
             bytes memory initializeBytecode = _initializeBytecode[i];
 
-            // Each input initialzieBytecode is a varible length bytes array which consists of a 32 byte prefix for the
+            // Each input initializeBytecode is a varible length bytes array which consists of a 32 byte prefix for the
             // length parameter, a 4 byte function selector, a 32 byte DelegatedManager address, and any additional parameters
             // as shown below:
             // [32 bytes - length parameter, 4 bytes - function selector, 32 bytes - DelegatedManager address, additional parameters]

--- a/contracts/interfaces/IManagerCore.sol
+++ b/contracts/interfaces/IManagerCore.sol
@@ -19,6 +19,7 @@ pragma solidity 0.6.10;
 
 interface IManagerCore {
     function addManager(address _manager) external;
-    function isManager(address _manager) external view returns(bool);
+    function isExtension(address _extension) external view returns(bool);
     function isFactory(address _factory) external view returns(bool);
+    function isManager(address _manager) external view returns(bool);
 }

--- a/contracts/lib/BaseGlobalExtension.sol
+++ b/contracts/lib/BaseGlobalExtension.sol
@@ -147,14 +147,11 @@ abstract contract BaseGlobalExtension {
     /**
      * ONLY MANAGER: Internal function to delete SetToken/Manager state from extension
      */
-    function _removeExtension() internal {
-        IDelegatedManager delegatedManager = IDelegatedManager(msg.sender);
-        ISetToken setToken = delegatedManager.setToken();
+    function _removeExtension(ISetToken _setToken, IDelegatedManager _delegatedManager) internal {
+        require(msg.sender == address(_manager(_setToken)), "Must be Manager");
 
-        require(msg.sender == address(_manager(setToken)), "Must be Manager");
+        delete setManagers[_setToken];
 
-        delete setManagers[setToken];
-
-        emit ExtensionRemoved(address(setToken), address(delegatedManager));
+        emit ExtensionRemoved(address(_setToken), address(_delegatedManager));
     }
 }

--- a/contracts/lib/BaseGlobalExtension.sol
+++ b/contracts/lib/BaseGlobalExtension.sol
@@ -1,5 +1,5 @@
 /*
-    Copyright 2021 Set Labs Inc.
+    Copyright 2022 Set Labs Inc.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -25,7 +25,7 @@ import { IDelegatedManager } from "../interfaces/IDelegatedManager.sol";
 import { IManagerCore } from "../interfaces/IManagerCore.sol";
 
 /**
- * @title BaseExtension
+ * @title BaseGlobalExtension
  * @author Set Protocol
  *
  * Abstract class that houses common global extension-related functions. Global extensions must

--- a/contracts/manager/DelegatedManager.sol
+++ b/contracts/manager/DelegatedManager.sol
@@ -175,6 +175,7 @@ contract DelegatedManager is Ownable, MutualUpgradeV2 {
         factory = _factory;
         methodologist = _methodologist;
         useAssetAllowlist = _useAssetAllowlist;
+        emit UseAssetAllowlistUpdated(_useAssetAllowlist);
 
         _addExtensions(_extensions);
         _addOperators(_operators);

--- a/contracts/manager/DelegatedManager.sol
+++ b/contracts/manager/DelegatedManager.sol
@@ -1,5 +1,5 @@
 /*
-    Copyright 2021 Set Labs Inc.
+    Copyright 2022 Set Labs Inc.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
@@ -235,7 +235,7 @@ contract DelegatedManager is Ownable, MutualUpgradeV2 {
     }
 
     /**
-     * ONLY OWNER: Remove an existing extension(s) tracked by the DelegatedManager. Removed extensions are
+     * ONLY OWNER: Remove existing extension(s) tracked by the DelegatedManager. Removed extensions are
      * placed in NONE state.
      *
      * @param _extensions           Old extension to remove
@@ -384,7 +384,7 @@ contract DelegatedManager is Ownable, MutualUpgradeV2 {
     }
 
     /**
-     * ONLY OWNER: Remove a new module from the SetToken.
+     * ONLY OWNER: Remove a module from the SetToken.
      *
      * @param _module           Module to remove
      */

--- a/contracts/mocks/BaseGlobalExtensionMock.sol
+++ b/contracts/mocks/BaseGlobalExtensionMock.sol
@@ -1,5 +1,5 @@
 /*
-    Copyright 2020 Set Labs Inc.
+    Copyright 2022 Set Labs Inc.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/contracts/mocks/BaseGlobalExtensionMock.sol
+++ b/contracts/mocks/BaseGlobalExtensionMock.sol
@@ -102,6 +102,9 @@ contract BaseGlobalExtensionMock is BaseGlobalExtension {
     {}
 
     function removeExtension() external override {
-        _removeExtension();
+        IDelegatedManager delegatedManager = IDelegatedManager(msg.sender);
+        ISetToken setToken = delegatedManager.setToken();
+
+        _removeExtension(setToken, delegatedManager);
     }
 }

--- a/contracts/mocks/BaseGlobalExtensionMock.sol
+++ b/contracts/mocks/BaseGlobalExtensionMock.sol
@@ -21,9 +21,9 @@ pragma solidity 0.6.10;
 import { ISetToken } from "@setprotocol/set-protocol-v2/contracts/interfaces/ISetToken.sol";
 
 import { BaseGlobalExtension } from "../lib/BaseGlobalExtension.sol";
-import { ModuleMock } from "./ModuleMock.sol";
-import { IManagerCore } from "../interfaces/IManagerCore.sol";
 import { IDelegatedManager } from "../interfaces/IDelegatedManager.sol";
+import { IManagerCore } from "../interfaces/IManagerCore.sol";
+import { ModuleMock } from "./ModuleMock.sol";
 
 contract BaseGlobalExtensionMock is BaseGlobalExtension {
 
@@ -67,6 +67,7 @@ contract BaseGlobalExtensionMock is BaseGlobalExtension {
         ISetToken setToken = _delegatedManager.setToken();
 
         _initializeExtension(setToken, _delegatedManager);
+
         bytes memory callData = abi.encodeWithSignature("initialize(address)", setToken);
         _invokeManager(_delegatedManager, address(module), callData);
     }

--- a/contracts/mocks/ModuleMock.sol
+++ b/contracts/mocks/ModuleMock.sol
@@ -1,0 +1,48 @@
+/*
+    Copyright 2020 Set Labs Inc.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+    SPDX-License-Identifier: Apache License, Version 2.0
+*/
+
+pragma solidity 0.6.10;
+
+import { IController } from "@setprotocol/set-protocol-v2/contracts/interfaces/IController.sol";
+import { ISetToken } from "@setprotocol/set-protocol-v2/contracts/interfaces/ISetToken.sol";
+import { ModuleBase } from "@setprotocol/set-protocol-v2/contracts/protocol/lib/ModuleBase.sol";
+
+contract ModuleMock is ModuleBase {
+
+    bool public removed;
+
+    /* ============ Constructor ============ */
+
+    constructor(IController _controller) public ModuleBase(_controller) {}
+
+    /* ============ External Functions ============ */
+
+    function initialize(
+        ISetToken _setToken
+    )
+        external
+        onlyValidAndPendingSet(_setToken)
+        onlySetManager(_setToken, msg.sender)
+    {
+        _setToken.initializeModule();
+    }
+
+    function removeModule() external override {
+        removed = true;
+    }
+}

--- a/contracts/mocks/ModuleMock.sol
+++ b/contracts/mocks/ModuleMock.sol
@@ -1,5 +1,5 @@
 /*
-    Copyright 2020 Set Labs Inc.
+    Copyright 2022 Set Labs Inc.
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/test/extensions/issuanceExtension.spec.ts
+++ b/test/extensions/issuanceExtension.spec.ts
@@ -98,7 +98,7 @@ describe("IssuanceExtension", () => {
 
     await setToken.setManager(delegatedManager.address);
 
-    await managerCore.initialize([factory.address]);
+    await managerCore.initialize([issuanceExtension.address], [factory.address]);
     await managerCore.connect(factory.wallet).addManager(delegatedManager.address);
 
     maxManagerFee = ether(.1);

--- a/test/extensions/streamingFeeSplitExtension.spec.ts
+++ b/test/extensions/streamingFeeSplitExtension.spec.ts
@@ -102,7 +102,7 @@ describe("StreamingFeeSplitExtension", () => {
 
     await setToken.setManager(delegatedManager.address);
 
-    await managerCore.initialize([factory.address]);
+    await managerCore.initialize([streamingFeeSplitExtension.address], [factory.address]);
     await managerCore.connect(factory.wallet).addManager(delegatedManager.address);
 
     feeRecipient = delegatedManager.address;

--- a/test/extensions/tradeExtension.spec.ts
+++ b/test/extensions/tradeExtension.spec.ts
@@ -96,7 +96,7 @@ describe("TradeExtension", () => {
 
     await setToken.setManager(delegatedManager.address);
 
-    await managerCore.initialize([factory.address]);
+    await managerCore.initialize([tradeExtension.address], [factory.address]);
     await managerCore.connect(factory.wallet).addManager(delegatedManager.address);
   });
 

--- a/test/factories/delegatedManagerFactory.spec.ts
+++ b/test/factories/delegatedManagerFactory.spec.ts
@@ -7,7 +7,8 @@ import {
   DelegatedManagerFactory,
   DelegatedManager,
   BaseGlobalExtensionMock,
-  ManagerCore
+  ManagerCore,
+  ModuleMock,
 } from "@utils/contracts/index";
 import DeployHelper from "@utils/deploys";
 import {
@@ -15,7 +16,6 @@ import {
   ether,
   getAccounts,
   getWaffleExpect,
-  getRandomAddress,
 } from "@utils/index";
 
 import { ProtocolUtils } from "@utils/common";
@@ -47,6 +47,8 @@ describe("DelegatedManagerFactory", () => {
   let delegatedManagerFactory: DelegatedManagerFactory;
   let mockFeeExtension: BaseGlobalExtensionMock;
   let mockIssuanceExtension: BaseGlobalExtensionMock;
+  let mockFeeModule: ModuleMock;
+  let mockIssuanceModule: ModuleMock;
 
   cacheBeforeEach(async () => {
     [
@@ -63,10 +65,15 @@ describe("DelegatedManagerFactory", () => {
     setV2Setup = getSystemFixture(owner.address);
     await setV2Setup.initialize();
 
+    mockFeeModule = await deployer.mocks.deployModuleMock(setV2Setup.controller.address);
+    mockIssuanceModule = await deployer.mocks.deployModuleMock(setV2Setup.controller.address);
+    await setV2Setup.controller.addModule(mockFeeModule.address);
+    await setV2Setup.controller.addModule(mockIssuanceModule.address);
+
     managerCore = await deployer.managerCore.deployManagerCore();
 
-    mockFeeExtension = await deployer.mocks.deployBaseGlobalExtensionMock(managerCore.address);
-    mockIssuanceExtension = await deployer.mocks.deployBaseGlobalExtensionMock(managerCore.address);
+    mockFeeExtension = await deployer.mocks.deployBaseGlobalExtensionMock(managerCore.address, mockFeeModule.address);
+    mockIssuanceExtension = await deployer.mocks.deployBaseGlobalExtensionMock(managerCore.address, mockIssuanceModule.address);
 
     delegatedManagerFactory = await deployer.factories.deployDelegatedManagerFactory(
       managerCore.address,
@@ -74,15 +81,20 @@ describe("DelegatedManagerFactory", () => {
       setV2Setup.factory.address
     );
 
-    await managerCore.initialize([delegatedManagerFactory.address]);
+    await managerCore.initialize(
+      [mockFeeExtension.address, mockIssuanceExtension.address],
+      [delegatedManagerFactory.address]
+    );
   });
 
   // Helper function to run a setup execution of either `createSetAndManager` or `createManager`
-  async function create(module: Address, extension: Address, existingSetToken?: Address): Promise<ContractTransaction> {
+  async function create(existingSetToken?: Address): Promise<ContractTransaction> {
     const tokens = [setV2Setup.dai.address, setV2Setup.wbtc.address];
     const operators = [operatorOne.address, operatorTwo.address];
     const otherAccountAddress = otherAccount.address;
     const methodologistAddress = methodologist.address;
+    const modules = [mockFeeModule.address, mockIssuanceModule.address];
+    const extensions = [mockFeeExtension.address, mockIssuanceExtension.address];
 
     if (existingSetToken === undefined) {
       return await delegatedManagerFactory.createSetAndManager(
@@ -92,10 +104,10 @@ describe("DelegatedManagerFactory", () => {
         "TT",
         otherAccountAddress,
         methodologistAddress,
-        [module],
+        modules,
         operators,
         tokens,
-        [extension]
+        extensions
       );
     }
 
@@ -105,22 +117,27 @@ describe("DelegatedManagerFactory", () => {
       methodologistAddress,
       operators,
       tokens,
-      [extension]
+      extensions
     );
   }
 
   // Helper function to generate bytecode packets for factory initialization call
-  async function generateBytecode(setToken: Address, manager: Address): Promise<string[]> {
-    const moduleBytecode = setV2Setup.issuanceModule.interface.encodeFunctionData("initialize", [
-      setToken,
-      await getRandomAddress()
-    ]);
-
-    const extensionBytecode = mockIssuanceExtension.interface.encodeFunctionData("initializeExtension", [
+  async function generateBytecode(manager: Address, issuanceModuleInitialzied: Boolean): Promise<string[]> {
+    const feeExtensionBytecode = mockFeeExtension.interface.encodeFunctionData("initializeModuleAndExtension", [
       manager
     ]);
 
-    return [moduleBytecode, extensionBytecode];
+    if (issuanceModuleInitialzied) {
+      const issuanceExtensionBytecode = mockIssuanceExtension.interface.encodeFunctionData("initializeExtension", [
+        manager
+      ]);
+      return [feeExtensionBytecode, issuanceExtensionBytecode];
+    } else {
+      const issuanceExtensionBytecode = mockIssuanceExtension.interface.encodeFunctionData("initializeModuleAndExtension", [
+        manager
+      ]);
+      return [feeExtensionBytecode, issuanceExtensionBytecode];
+    }
   }
 
   describe("#constructor", async () => {
@@ -551,8 +568,6 @@ describe("DelegatedManagerFactory", () => {
   });
 
   describe("initialize", () => {
-    let module: Address;
-    let extension: Address;
     let manager: DelegatedManager;
     let initializeParams: any;
     let setToken: SetToken;
@@ -562,15 +577,14 @@ describe("DelegatedManagerFactory", () => {
     let subjectSetToken: Address;
     let subjectOwnerFeeSplit: BigNumber;
     let subjectOwnerFeeRecipient: Address;
-    let subjectInitializeTargets: Address[];
+    let subjectExtensions: Address[];
     let subjectInitializeBytecode: string[];
 
     beforeEach(() => {
       subjectCaller = owner;
       subjectOwnerFeeSplit = ether(.5);
       subjectOwnerFeeRecipient = otherAccount.address;
-      subjectInitializeTargets = [];
-      subjectInitializeBytecode = [];
+      subjectExtensions = [mockFeeExtension.address, mockIssuanceExtension.address];
     });
 
     async function subject(): Promise<ContractTransaction> {
@@ -578,19 +592,16 @@ describe("DelegatedManagerFactory", () => {
         subjectSetToken,
         subjectOwnerFeeSplit,
         subjectOwnerFeeRecipient,
-        subjectInitializeTargets,
+        subjectExtensions,
         subjectInitializeBytecode
       );
     }
 
     describe("when the SetToken was created by the factory", () => {
       cacheBeforeEach(async () => {
-        module = setV2Setup.issuanceModule.address;
-        extension = mockIssuanceExtension.address;
+        const tx = await create();
 
-        const tx = await create(module, extension);
         setTokenAddress = await protocolUtils.getCreatedSetTokenAddress(tx.hash);
-
         initializeParams = await delegatedManagerFactory.initializeState(setTokenAddress);
         manager = await deployer.manager.getDelegatedManager(initializeParams.manager);
         setToken = await deployer.setV2.getSetToken(setTokenAddress);
@@ -599,20 +610,21 @@ describe("DelegatedManagerFactory", () => {
       });
 
       beforeEach(async () => {
-        subjectInitializeTargets = [module, extension];
-        subjectInitializeBytecode = await generateBytecode(setTokenAddress, initializeParams.manager);
+        subjectInitializeBytecode = await generateBytecode(initializeParams.manager, false);
       });
 
-      it("should initialize the module", async() => {
+      it("should initialize the modules", async() => {
         await subject();
 
-        expect(await setToken.moduleStates(module)).eq(MODULE_STATE.INITIALIZED);
+        expect(await setToken.moduleStates(mockFeeModule.address)).eq(MODULE_STATE.INITIALIZED);
+        expect(await setToken.moduleStates(mockIssuanceModule.address)).eq(MODULE_STATE.INITIALIZED);
       });
 
-      it("should initialize the extension", async() => {
+      it("should initialize the extensions", async() => {
         await subject();
 
-        expect(await manager.isInitializedExtension(extension)).eq(true);
+        expect(await manager.isInitializedExtension(mockFeeExtension.address)).eq(true);
+        expect(await manager.isInitializedExtension(mockIssuanceExtension.address)).eq(true);
       });
 
       it("should set the ownerFeeSplit on the DelegatedManager", async() => {
@@ -678,69 +690,42 @@ describe("DelegatedManagerFactory", () => {
           initializeParams.manager
         );
       });
-
-      describe("when the factory is not approved by the ManagerCore", async() => {
-        beforeEach(async () => {
-          await managerCore.connect(owner.wallet).removeManager(manager.address);
-        });
-
-        it("should revert", async() => {
-          await expect(subject()).to.be.revertedWith("Must be ManagerCore-enabled manager");
-        });
-      });
-
-      describe("when a SetToken is in initializeTargets", async() => {
-        beforeEach(async () => {
-          subjectInitializeTargets = [setTokenAddress];
-
-          subjectInitializeBytecode = [setToken.interface.encodeFunctionData(
-            "setManager",
-            [otherAccount.address]
-          )];
-        });
-
-        it("should revert", async() => {
-          await expect(subject()).to.be.revertedWith("Target must not be SetToken");
-        });
-      });
     });
 
     describe("when a SetToken is being migrated to a DelegatedManager", async () => {
       cacheBeforeEach(async () => {
-        module = setV2Setup.issuanceModule.address;
-        extension = mockIssuanceExtension.address;
-
         setToken = await setV2Setup.createSetToken(
           [setV2Setup.dai.address],
           [ether(1)],
-          [setV2Setup.issuanceModule.address]
+          [mockFeeModule.address, mockIssuanceModule.address]
         );
 
-        await create(module, extension, setToken.address);
+        // Initialize only the IssuanceModule, to check ability of factory to handle initializeExtension
+        await mockIssuanceModule.initialize(setToken.address);
+
+        await create(setToken.address);
 
         initializeParams = await delegatedManagerFactory.initializeState(setToken.address);
         manager = await deployer.manager.getDelegatedManager(initializeParams.manager);
-        setToken = await deployer.setV2.getSetToken(setToken.address);
 
         subjectSetToken = setToken.address;
       });
 
       beforeEach(async () => {
-        const extensionBytecode = (await generateBytecode(setToken.address, manager.address))[1];
-        subjectInitializeTargets = [extension];
-        subjectInitializeBytecode = [extensionBytecode];
+        subjectInitializeBytecode = await generateBytecode(initializeParams.manager, true);
       });
 
       it("should initialize the module", async() => {
         await subject();
 
-        expect(await setToken.moduleStates(module)).eq(MODULE_STATE.PENDING);
+        expect(await setToken.moduleStates(mockFeeModule.address)).eq(MODULE_STATE.PENDING);
       });
 
-      it("should initialize the extension", async() => {
+      it("should initialize the extensions", async() => {
         await subject();
 
-        expect(await manager.isInitializedExtension(extension)).eq(true);
+        expect(await manager.isInitializedExtension(mockFeeExtension.address)).eq(true);
+        expect(await manager.isInitializedExtension(mockIssuanceExtension.address)).eq(true);
       });
 
       it("should set the ownerFeeSplit on the DelegatedManager", async() => {
@@ -798,31 +783,6 @@ describe("DelegatedManagerFactory", () => {
         expect(finalInitializeParams.manager).eq(ADDRESS_ZERO);
         expect(finalInitializeParams.isPending).eq(false);
       });
-
-      describe("when the factory is not approved by the ManagerCore", async() => {
-        beforeEach(async () => {
-          await managerCore.connect(owner.wallet).removeManager(manager.address);
-        });
-
-        it("should revert", async() => {
-          await expect(subject()).to.be.revertedWith("Must be ManagerCore-enabled manager");
-        });
-      });
-
-      describe("when a SetToken is in initializeTargets", async() => {
-        beforeEach(async () => {
-          subjectInitializeTargets = [setToken.address];
-
-          subjectInitializeBytecode = [setToken.interface.encodeFunctionData(
-            "setManager",
-            [otherAccount.address]
-          )];
-        });
-
-        it("should revert", async() => {
-          await expect(subject()).to.be.revertedWith("Target must not be SetToken");
-        });
-      });
     });
 
     describe("when the initialization state is not pending", async() => {
@@ -831,9 +791,41 @@ describe("DelegatedManagerFactory", () => {
       });
     });
 
+    describe("when the factory is not approved by the ManagerCore", async() => {
+      beforeEach(async () => {
+        await create();
+
+        await managerCore.connect(owner.wallet).removeManager(manager.address);
+      });
+
+      it("should revert", async() => {
+        await expect(subject()).to.be.revertedWith("Must be ManagerCore-enabled manager");
+      });
+    });
+
+    describe("when an input Extension is not approved by the ManagerCore", async() => {
+      let mockUnapprovedExtension: BaseGlobalExtensionMock;
+
+      beforeEach(async () => {
+        await create();
+
+        mockUnapprovedExtension = await deployer.mocks.deployBaseGlobalExtensionMock(managerCore.address, mockFeeModule.address);
+        subjectExtensions = [mockUnapprovedExtension.address];
+
+        subjectInitializeBytecode = [mockUnapprovedExtension.interface.encodeFunctionData(
+          "initializeExtension",
+          [manager.address]
+        )];
+      });
+
+      it("should revert", async() => {
+        await expect(subject()).to.be.revertedWith("Target must be ManagerCore-enabled Extension");
+      });
+    });
+
     describe("when the caller is not the deployer", async() => {
       beforeEach(async() => {
-        await create(module, extension);
+        await create();
         subjectCaller = otherAccount;
       });
 
@@ -842,14 +834,14 @@ describe("DelegatedManagerFactory", () => {
       });
     });
 
-    describe("when initializeTargets and initializeBytecodes do not have the same length", async() => {
+    describe("when extensions and initializeBytecodes do not have the same length", async() => {
       beforeEach(async () => {
-        await create(module, extension);
+        await create();
         subjectInitializeBytecode = [];
       });
 
       it("should revert", async() => {
-        await expect(subject()).to.be.revertedWith("Array length must be > 0");
+        await expect(subject()).to.be.revertedWith("Array length mismatch");
       });
     });
   });

--- a/test/factories/delegatedManagerFactory.spec.ts
+++ b/test/factories/delegatedManagerFactory.spec.ts
@@ -16,6 +16,7 @@ import {
   ether,
   getAccounts,
   getWaffleExpect,
+  getRandomAccount,
 } from "@utils/index";
 
 import { ProtocolUtils } from "@utils/common";
@@ -573,7 +574,7 @@ describe("DelegatedManagerFactory", () => {
     });
   });
 
-  describe("initialize", () => {
+  describe("#initialize", () => {
     let manager: DelegatedManager;
     let initializeParams: any;
     let setToken: SetToken;
@@ -827,6 +828,25 @@ describe("DelegatedManagerFactory", () => {
 
       it("should revert", async() => {
         await expect(subject()).to.be.revertedWith("Target must be ManagerCore-enabled Extension");
+      });
+    });
+
+    describe("when an initializeBytecode targets the wrong DelegatedManager", async() => {
+      let otherDelegatedManager: Account;
+
+      beforeEach(async () => {
+        await create();
+        otherDelegatedManager = await getRandomAccount();
+
+        subjectExtensions = [mockFeeExtension.address];
+        subjectInitializeBytecode = [mockFeeExtension.interface.encodeFunctionData(
+          "initializeExtension",
+          [otherDelegatedManager.address]
+        )];
+      });
+
+      it("should revert", async() => {
+        await expect(subject()).to.be.revertedWith("Must target correct DelegatedManager");
       });
     });
 

--- a/test/lib/baseGlobalExtension.spec.ts
+++ b/test/lib/baseGlobalExtension.spec.ts
@@ -41,6 +41,7 @@ describe("BaseGlobalExtension", () => {
   let managerCore: ManagerCore;
   let delegatedManager: DelegatedManager;
   let baseExtensionMock: BaseGlobalExtensionMock;
+  let mockModule: Account;
 
   before(async () => {
     [
@@ -49,6 +50,7 @@ describe("BaseGlobalExtension", () => {
       otherAccount,
       factory,
       operator,
+      mockModule,
     ] = await getAccounts();
 
     deployer = new DeployHelper(owner.wallet);
@@ -77,7 +79,7 @@ describe("BaseGlobalExtension", () => {
 
     managerCore = await deployer.managerCore.deployManagerCore();
 
-    baseExtensionMock = await deployer.mocks.deployBaseGlobalExtensionMock(managerCore.address);
+    baseExtensionMock = await deployer.mocks.deployBaseGlobalExtensionMock(managerCore.address, mockModule.address);
 
     // Deploy DelegatedManager
     delegatedManager = await deployer.manager.deployDelegatedManager(

--- a/test/lib/baseGlobalExtension.spec.ts
+++ b/test/lib/baseGlobalExtension.spec.ts
@@ -95,7 +95,7 @@ describe("BaseGlobalExtension", () => {
     // Transfer ownership to DelegatedManager
     await setToken.setManager(delegatedManager.address);
 
-    await managerCore.initialize([factory.address]);
+    await managerCore.initialize([baseExtensionMock.address], [factory.address]);
     await managerCore.connect(factory.wallet).addManager(delegatedManager.address);
 
     await baseExtensionMock.initializeExtension(delegatedManager.address);

--- a/test/manager/delegatedManager.spec.ts
+++ b/test/manager/delegatedManager.spec.ts
@@ -95,7 +95,7 @@ describe("DelegatedManager", () => {
     // Transfer ownership to DelegatedManager
     await setToken.setManager(delegatedManager.address);
 
-    await managerCore.initialize([factory.address]);
+    await managerCore.initialize([baseExtension.address], [factory.address]);
     await managerCore.connect(factory.wallet).addManager(delegatedManager.address);
   });
 

--- a/test/manager/delegatedManager.spec.ts
+++ b/test/manager/delegatedManager.spec.ts
@@ -38,6 +38,7 @@ describe("DelegatedManager", () => {
   let managerCore: ManagerCore;
   let delegatedManager: DelegatedManager;
   let baseExtension: BaseGlobalExtensionMock;
+  let mockModule: Account;
 
   before(async () => {
     [
@@ -48,7 +49,8 @@ describe("DelegatedManager", () => {
       operatorOne,
       operatorTwo,
       fakeExtension,
-      newManager
+      newManager,
+      mockModule
     ] = await getAccounts();
 
     deployer = new DeployHelper(owner.wallet);
@@ -77,7 +79,7 @@ describe("DelegatedManager", () => {
 
     managerCore = await deployer.managerCore.deployManagerCore();
 
-    baseExtension = await deployer.mocks.deployBaseGlobalExtensionMock(managerCore.address);
+    baseExtension = await deployer.mocks.deployBaseGlobalExtensionMock(managerCore.address, mockModule.address);
 
     // Deploy DelegatedManager
     delegatedManager = await deployer.manager.deployDelegatedManager(

--- a/test/manager/delegatedManager.spec.ts
+++ b/test/manager/delegatedManager.spec.ts
@@ -17,6 +17,7 @@ import {
 import { SystemFixture } from "@setprotocol/set-protocol-v2/utils/fixtures";
 import { getSystemFixture, getRandomAccount } from "@setprotocol/set-protocol-v2/utils/test";
 import { ContractTransaction } from "ethers";
+import { getLastBlockTransaction } from "@utils/test/testingUtils";
 
 const expect = getWaffleExpect();
 
@@ -163,9 +164,11 @@ describe("DelegatedManager", () => {
       expect(isApprovedExtension).to.eq(EXTENSION_STATE["PENDING"]);
     });
 
-    // it("should emit the correct ExtensionAdded events", async () => {
-    //   await expect(subject()).to.emit(delegatedManager, "ExtensionAdded").withArgs(baseExtension.address);
-    // });
+    it("should emit the correct ExtensionAdded events", async () => {
+      const delegatedManager = await subject();
+
+      await expect(getLastBlockTransaction()).to.emit(delegatedManager, "ExtensionAdded").withArgs(baseExtension.address);
+    });
 
     it("should set the correct Operators approvals and arrays", async () => {
       const delegatedManager = await subject();
@@ -179,10 +182,12 @@ describe("DelegatedManager", () => {
       expect(isApprovedOperatorTwo).to.be.true;
     });
 
-    // it("should emit the correct OperatorAdded events", async () => {
-    //   await expect(subject()).to.emit(delegatedManager, "OperatorAdded").withArgs(operatorOne.address);
-    //   await expect(subject()).to.emit(delegatedManager, "OperatorAdded").withArgs(operatorTwo.address);
-    // });
+    it("should emit the correct OperatorAdded events", async () => {
+      const delegatedManager = await subject();
+
+      await expect(getLastBlockTransaction()).to.emit(delegatedManager, "OperatorAdded").withArgs(operatorOne.address);
+      await expect(getLastBlockTransaction()).to.emit(delegatedManager, "OperatorAdded").withArgs(operatorTwo.address);
+    });
 
     it("should set the correct Allowed assets approvals and arrays", async () => {
       const delegatedManager = await subject();
@@ -196,10 +201,12 @@ describe("DelegatedManager", () => {
       expect(isApprovedWETH).to.be.true;
     });
 
-    // it("should emit the correct AllowedAssetAdded events", async () => {
-    //   await expect(subject()).to.emit(delegatedManager, "AllowedAssetAdded").withArgs(setV2Setup.usdc.address);
-    //   await expect(subject()).to.emit(delegatedManager, "AllowedAssetAdded").withArgs(setV2Setup.weth.address);
-    // });
+    it("should emit the correct AllowedAssetAdded events", async () => {
+      const delegatedManager = await subject();
+
+      await expect(getLastBlockTransaction()).to.emit(delegatedManager, "AllowedAssetAdded").withArgs(setV2Setup.usdc.address);
+      await expect(getLastBlockTransaction()).to.emit(delegatedManager, "AllowedAssetAdded").withArgs(setV2Setup.weth.address);
+    });
 
     it("should indicate whether to use the asset allow list", async () => {
       const delegatedManager = await subject();
@@ -209,9 +216,11 @@ describe("DelegatedManager", () => {
       expect(useAllowList).to.be.true;
     });
 
-    // it("should emit the correct UseAssetAllowlistUpdated event", async () => {
-    //   await expect(subject()).to.emit(delegatedManager, "UseAssetAllowlistUpdated").withArgs(true);
-    // });
+    it("should emit the correct UseAssetAllowlistUpdated event", async () => {
+      const delegatedManager = await subject();
+
+      await expect(getLastBlockTransaction()).to.emit(delegatedManager, "UseAssetAllowlistUpdated").withArgs(true);
+    });
   });
 
   describe("#initializeExtension", async () => {

--- a/test/manager/delegatedManager.spec.ts
+++ b/test/manager/delegatedManager.spec.ts
@@ -163,6 +163,10 @@ describe("DelegatedManager", () => {
       expect(isApprovedExtension).to.eq(EXTENSION_STATE["PENDING"]);
     });
 
+    // it("should emit the correct ExtensionAdded events", async () => {
+    //   await expect(subject()).to.emit(delegatedManager, "ExtensionAdded").withArgs(baseExtension.address);
+    // });
+
     it("should set the correct Operators approvals and arrays", async () => {
       const delegatedManager = await subject();
 
@@ -174,6 +178,11 @@ describe("DelegatedManager", () => {
       expect(isApprovedOperatorOne).to.be.true;
       expect(isApprovedOperatorTwo).to.be.true;
     });
+
+    // it("should emit the correct OperatorAdded events", async () => {
+    //   await expect(subject()).to.emit(delegatedManager, "OperatorAdded").withArgs(operatorOne.address);
+    //   await expect(subject()).to.emit(delegatedManager, "OperatorAdded").withArgs(operatorTwo.address);
+    // });
 
     it("should set the correct Allowed assets approvals and arrays", async () => {
       const delegatedManager = await subject();
@@ -187,6 +196,11 @@ describe("DelegatedManager", () => {
       expect(isApprovedWETH).to.be.true;
     });
 
+    // it("should emit the correct AllowedAssetAdded events", async () => {
+    //   await expect(subject()).to.emit(delegatedManager, "AllowedAssetAdded").withArgs(setV2Setup.usdc.address);
+    //   await expect(subject()).to.emit(delegatedManager, "AllowedAssetAdded").withArgs(setV2Setup.weth.address);
+    // });
+
     it("should indicate whether to use the asset allow list", async () => {
       const delegatedManager = await subject();
 
@@ -194,6 +208,10 @@ describe("DelegatedManager", () => {
 
       expect(useAllowList).to.be.true;
     });
+
+    // it("should emit the correct UseAssetAllowlistUpdated event", async () => {
+    //   await expect(subject()).to.emit(delegatedManager, "UseAssetAllowlistUpdated").withArgs(true);
+    // });
   });
 
   describe("#initializeExtension", async () => {

--- a/test/managerCore.spec.ts
+++ b/test/managerCore.spec.ts
@@ -245,16 +245,6 @@ describe("ManagerCore", () => {
         await expect(subject()).to.be.revertedWith("Contract must be initialized.");
       });
     });
-
-    describe("when zero address passed for a manager", async () => {
-      beforeEach(async () => {
-        subjectManager = ADDRESS_ZERO;
-      });
-
-      it("should revert", async () => {
-        await expect(subject()).to.be.revertedWith("Zero address submitted.");
-      });
-    });
   });
 
   describe("#removeManager", async () => {

--- a/test/managerCore.spec.ts
+++ b/test/managerCore.spec.ts
@@ -79,16 +79,35 @@ describe("ManagerCore", () => {
 
   describe("#initialize", async () => {
     let subjectCaller: Account;
+    let subjectExtensions: Address[];
     let subjectFactories: Address[];
 
     beforeEach(async () => {
       subjectCaller = owner;
+      subjectExtensions = [mockExtension.address];
       subjectFactories = [delegatedManagerFactory.address];
     });
 
     async function subject(): Promise<any> {
-      return await managerCore.connect(subjectCaller.wallet).initialize(subjectFactories);
+      return await managerCore.connect(subjectCaller.wallet).initialize(
+        subjectExtensions,
+        subjectFactories
+      );
     }
+
+    it("should have set the correct extensions length of 1", async () => {
+      await subject();
+
+      const extensions = await managerCore.getExtensions();
+      expect(extensions.length).to.eq(1);
+    });
+
+    it("should have a valid extension", async () => {
+      await subject();
+
+      const validExtension = await managerCore.isExtension(mockExtension.address);
+      expect(validExtension).to.eq(true);
+    });
 
     it("should have set the correct factories length of 1", async () => {
       await subject();
@@ -148,7 +167,7 @@ describe("ManagerCore", () => {
     let subjectCaller: Account;
 
     beforeEach(async () => {
-      managerCore.initialize([]);
+      managerCore.initialize([], []);
       managerCore.addFactory(mockDelegatedManagerFactory.address);
 
       subjectManagerCore = managerCore;
@@ -216,7 +235,7 @@ describe("ManagerCore", () => {
     let subjectCaller: Account;
 
     beforeEach(async () => {
-      await managerCore.initialize([]);
+      await managerCore.initialize([], []);
       await managerCore.addFactory(mockDelegatedManagerFactory.address);
       await managerCore.connect(mockDelegatedManagerFactory.wallet).addManager(mockManager.address);
 
@@ -284,7 +303,7 @@ describe("ManagerCore", () => {
     let subjectManagerCore: ManagerCore;
 
     beforeEach(async () => {
-      await managerCore.initialize([]);
+      await managerCore.initialize([], []);
 
       subjectFactory = delegatedManagerFactory.address;
       subjectCaller = owner;
@@ -350,7 +369,7 @@ describe("ManagerCore", () => {
     let subjectManagerCore: ManagerCore;
 
     beforeEach(async () => {
-      await managerCore.initialize([delegatedManagerFactory.address]);
+      await managerCore.initialize([], [delegatedManagerFactory.address]);
 
       subjectFactory = delegatedManagerFactory.address;
       subjectCaller = owner;
@@ -416,7 +435,7 @@ describe("ManagerCore", () => {
     let subjectManagerCore: ManagerCore;
 
     beforeEach(async () => {
-      await managerCore.initialize([]);
+      await managerCore.initialize([], []);
 
       subjectExtension = mockExtension.address;
       subjectCaller = owner;
@@ -482,8 +501,7 @@ describe("ManagerCore", () => {
     let subjectManagerCore: ManagerCore;
 
     beforeEach(async () => {
-      await managerCore.initialize([]);
-      await managerCore.addExtension(mockExtension.address);
+      await managerCore.initialize([mockExtension.address], []);
 
       subjectExtension = mockExtension.address;
       subjectCaller = owner;

--- a/test/managerCore.spec.ts
+++ b/test/managerCore.spec.ts
@@ -4,7 +4,8 @@ import { Account, Address } from "@utils/types";
 import { ADDRESS_ZERO } from "@utils/constants";
 import {
   DelegatedManagerFactory,
-  ManagerCore
+  ManagerCore,
+  BaseGlobalExtensionMock
 } from "@utils/contracts/index";
 import DeployHelper from "@utils/deploys";
 import {
@@ -22,18 +23,21 @@ describe("ManagerCore", () => {
   let owner: Account;
   let mockDelegatedManagerFactory: Account;
   let mockManager: Account;
+  let mockModule: Account;
 
   let deployer: DeployHelper;
   let setV2Setup: SystemFixture;
 
   let managerCore: ManagerCore;
   let delegatedManagerFactory: DelegatedManagerFactory;
+  let mockExtension: BaseGlobalExtensionMock;
 
   before(async () => {
     [
       owner,
       mockDelegatedManagerFactory,
-      mockManager
+      mockManager,
+      mockModule,
     ] = await getAccounts();
 
     deployer = new DeployHelper(owner.wallet);
@@ -42,6 +46,8 @@ describe("ManagerCore", () => {
     await setV2Setup.initialize();
 
     managerCore = await deployer.managerCore.deployManagerCore();
+
+    mockExtension = await deployer.mocks.deployBaseGlobalExtensionMock(managerCore.address, mockModule.address);
 
     delegatedManagerFactory = await deployer.factories.deployDelegatedManagerFactory(
       managerCore.address,
@@ -400,6 +406,139 @@ describe("ManagerCore", () => {
 
       it("should revert", async () => {
         await expect(subject()).to.be.revertedWith("Factory does not exist");
+      });
+    });
+  });
+
+  describe("#addExtension", async () => {
+    let subjectExtension: Address;
+    let subjectCaller: Account;
+    let subjectManagerCore: ManagerCore;
+
+    beforeEach(async () => {
+      await managerCore.initialize([]);
+
+      subjectExtension = mockExtension.address;
+      subjectCaller = owner;
+      subjectManagerCore = managerCore;
+    });
+
+    async function subject(): Promise<any> {
+      return await subjectManagerCore.connect(subjectCaller.wallet).addExtension(subjectExtension);
+    }
+
+    it("should be stored in the extensions array", async () => {
+      await subject();
+
+      const extensions = await managerCore.getExtensions();
+      expect(extensions.length).to.eq(1);
+    });
+
+    it("should be returned as a valid extension", async () => {
+      await subject();
+
+      const validExtension = await managerCore.isExtension(mockExtension.address);
+      expect(validExtension).to.eq(true);
+    });
+
+    it("should emit the ExtensionAdded event", async () => {
+      await expect(subject()).to.emit(managerCore, "ExtensionAdded").withArgs(subjectExtension);
+    });
+
+    describe("when the ManagerCore is not initialized", async () => {
+      beforeEach(async () => {
+        subjectManagerCore = await deployer.managerCore.deployManagerCore();
+      });
+
+      it("should revert", async () => {
+        await expect(subject()).to.be.revertedWith("Contract must be initialized.");
+      });
+    });
+
+    describe("when the sender is not the owner", async () => {
+      beforeEach(async () => {
+        subjectCaller = await getRandomAccount();
+      });
+
+      it("should revert", async () => {
+        await expect(subject()).to.be.revertedWith("Ownable: caller is not the owner");
+      });
+    });
+
+    describe("when the extension already exists", async () => {
+      beforeEach(async () => {
+        await subject();
+      });
+
+      it("should revert", async () => {
+        await expect(subject()).to.be.revertedWith("Extension already exists");
+      });
+    });
+  });
+
+  describe("#removeExtension", async () => {
+    let subjectExtension: Address;
+    let subjectCaller: Account;
+    let subjectManagerCore: ManagerCore;
+
+    beforeEach(async () => {
+      await managerCore.initialize([]);
+      await managerCore.addExtension(mockExtension.address);
+
+      subjectExtension = mockExtension.address;
+      subjectCaller = owner;
+      subjectManagerCore = managerCore;
+    });
+
+    async function subject(): Promise<any> {
+      return await subjectManagerCore.connect(subjectCaller.wallet).removeExtension(subjectExtension);
+    }
+
+    it("should remove extension from extensions array", async () => {
+      await subject();
+
+      const extensions = await managerCore.getExtensions();
+      expect(extensions.length).to.eq(0);
+    });
+
+    it("should return false as a valid extension", async () => {
+      await subject();
+
+      const validExtension = await managerCore.isExtension(mockExtension.address);
+      expect(validExtension).to.eq(false);
+    });
+
+    it("should emit the ExtensionRemoved event", async () => {
+      await expect(subject()).to.emit(managerCore, "ExtensionRemoved").withArgs(subjectExtension);
+    });
+
+    describe("when the ManagerCore is not initialized", async () => {
+      beforeEach(async () => {
+        subjectManagerCore = await deployer.managerCore.deployManagerCore();
+      });
+
+      it("should revert", async () => {
+        await expect(subject()).to.be.revertedWith("Contract must be initialized.");
+      });
+    });
+
+    describe("when the sender is not the owner", async () => {
+      beforeEach(async () => {
+        subjectCaller = await getRandomAccount();
+      });
+
+      it("should revert", async () => {
+        await expect(subject()).to.be.revertedWith("Ownable: caller is not the owner");
+      });
+    });
+
+    describe("when the extension does not exist", async () => {
+      beforeEach(async () => {
+        await subject();
+      });
+
+      it("should revert", async () => {
+        await expect(subject()).to.be.revertedWith("Extension does not exist");
       });
     });
   });

--- a/test/managerCore.spec.ts
+++ b/test/managerCore.spec.ts
@@ -245,6 +245,16 @@ describe("ManagerCore", () => {
         await expect(subject()).to.be.revertedWith("Contract must be initialized.");
       });
     });
+
+    describe("when zero address passed for a manager", async () => {
+      beforeEach(async () => {
+        subjectManager = ADDRESS_ZERO;
+      });
+
+      it("should revert", async () => {
+        await expect(subject()).to.be.revertedWith("Zero address submitted.");
+      });
+    });
   });
 
   describe("#removeManager", async () => {
@@ -367,6 +377,16 @@ describe("ManagerCore", () => {
 
       it("should revert", async () => {
         await expect(subject()).to.be.revertedWith("Ownable: caller is not the owner");
+      });
+    });
+
+    describe("when zero address passed for a factory", async () => {
+      beforeEach(async () => {
+        subjectFactory = ADDRESS_ZERO;
+      });
+
+      it("should revert", async () => {
+        await expect(subject()).to.be.revertedWith("Zero address submitted.");
       });
     });
 
@@ -499,6 +519,16 @@ describe("ManagerCore", () => {
 
       it("should revert", async () => {
         await expect(subject()).to.be.revertedWith("Ownable: caller is not the owner");
+      });
+    });
+
+    describe("when zero address passed for an extension", async () => {
+      beforeEach(async () => {
+        subjectExtension = ADDRESS_ZERO;
+      });
+
+      it("should revert", async () => {
+        await expect(subject()).to.be.revertedWith("Zero address submitted.");
       });
     });
 

--- a/test/managerCore.spec.ts
+++ b/test/managerCore.spec.ts
@@ -109,6 +109,10 @@ describe("ManagerCore", () => {
       expect(validExtension).to.eq(true);
     });
 
+    it("should emit the ExtensionAdded event", async () => {
+      await expect(subject()).to.emit(managerCore, "ExtensionAdded").withArgs(mockExtension.address);
+    });
+
     it("should have set the correct factories length of 1", async () => {
       await subject();
 
@@ -121,6 +125,10 @@ describe("ManagerCore", () => {
 
       const validFactory = await managerCore.isFactory(delegatedManagerFactory.address);
       expect(validFactory).to.eq(true);
+    });
+
+    it("should emit the FactoryAdded event", async () => {
+      await expect(subject()).to.emit(managerCore, "FactoryAdded").withArgs(delegatedManagerFactory.address);
     });
 
     it("should initialize the ManagerCore", async () => {
@@ -137,6 +145,16 @@ describe("ManagerCore", () => {
 
       it("should revert", async () => {
         await expect(subject()).to.be.revertedWith("Ownable: caller is not the owner");
+      });
+    });
+
+    describe("when zero address passed for extension", async () => {
+      beforeEach(async () => {
+        subjectExtensions = [ADDRESS_ZERO];
+      });
+
+      it("should revert", async () => {
+        await expect(subject()).to.be.revertedWith("Zero address submitted.");
       });
     });
 

--- a/utils/contracts/index.ts
+++ b/utils/contracts/index.ts
@@ -7,6 +7,7 @@ export { DelegatedManager } from "../../typechain/DelegatedManager";
 export { DelegatedManagerFactory } from "../../typechain/DelegatedManagerFactory";
 export { ManagerCore } from "../../typechain/ManagerCore";
 export { ManagerMock } from "../../typechain/ManagerMock";
+export { ModuleMock } from "../../typechain/ModuleMock";
 export { MutualUpgradeMock } from "../../typechain/MutualUpgradeMock";
 export { MutualUpgradeV2Mock } from "../../typechain/MutualUpgradeV2Mock";
 export { PerpV2LeverageStrategyExtension } from "../../typechain/PerpV2LeverageStrategyExtension";

--- a/utils/deploys/deployMocks.ts
+++ b/utils/deploys/deployMocks.ts
@@ -5,6 +5,7 @@ import {
   BaseExtensionMock,
   BaseGlobalExtensionMock,
   ManagerMock,
+  ModuleMock,
   MutualUpgradeMock,
   StandardTokenMock,
   StringArrayUtilsMock,
@@ -20,6 +21,7 @@ import { AddressArrayUtilsMock__factory } from "../../typechain/factories/Addres
 import { BaseExtensionMock__factory } from "../../typechain/factories/BaseExtensionMock__factory";
 import { BaseGlobalExtensionMock__factory } from "../../typechain/factories/BaseGlobalExtensionMock__factory";
 import { ManagerMock__factory } from "../../typechain/factories/ManagerMock__factory";
+import { ModuleMock__factory } from "../../typechain/factories/ModuleMock__factory";
 import { ChainlinkAggregatorMock__factory  } from "@setprotocol/set-protocol-v2/typechain";
 import { ContractCallerMock__factory } from "@setprotocol/set-protocol-v2/typechain";
 import { MutualUpgradeMock__factory } from "../../typechain/factories/MutualUpgradeMock__factory";
@@ -39,12 +41,16 @@ export default class DeployMocks {
     return await new BaseExtensionMock__factory(this._deployerSigner).deploy(manager);
   }
 
-  public async deployBaseGlobalExtensionMock(managerCore: Address): Promise<BaseGlobalExtensionMock> {
-    return await new BaseGlobalExtensionMock__factory(this._deployerSigner).deploy(managerCore);
+  public async deployBaseGlobalExtensionMock(managerCore: Address, module: Address): Promise<BaseGlobalExtensionMock> {
+    return await new BaseGlobalExtensionMock__factory(this._deployerSigner).deploy(managerCore, module);
   }
 
   public async deployManagerMock(setToken: Address): Promise<ManagerMock> {
     return await new ManagerMock__factory(this._deployerSigner).deploy(setToken);
+  }
+
+  public async deployModuleMock(controller: Address): Promise<ModuleMock> {
+    return await new ModuleMock__factory(this._deployerSigner).deploy(controller);
   }
 
   public async deployAddressArrayUtilsMock(): Promise<AddressArrayUtilsMock> {

--- a/utils/test/testingUtils.ts
+++ b/utils/test/testingUtils.ts
@@ -72,6 +72,10 @@ export async function getLastBlockTimestamp(): Promise<BigNumber> {
   return BigNumber.from((await provider.getBlock("latest")).timestamp);
 }
 
+export async function getLastBlockTransaction(): Promise<any> {
+  return (await provider.getBlockWithTransactions("latest")).transactions[0];
+}
+
 export async function mineBlockAsync(): Promise<any> {
   await sendJSONRpcRequestAsync("evm_mine", []);
 }


### PR DESCRIPTION
Internal audit fixes
- Track `extensions` on `ManagerCore`
- Require targets in `DelegatedManagerFactory.initialize()` are ManagerCore-tracked `extensions`
- Require first argument of `initializeBytecode` in `DelegatedManagerFactory.initialize()` is the appropriate `DelegatedManager` address
- Add javadoc notes to `IssuanceExtension` and `StreamingFeeSplitExtension`
    - Note subtle difference between two extensions in which fees are distributed
- Change function signature of `BaseGlobalExtension._removeExtension` to include `setToken` and `delegatedManager`
- Group manager state setting logic during `DelegatedManagerFactory.initialize()` into an internal function, `_setManagerState()`
- Address javadoc nits

Event additions
- emit `ExtensionAdded` and `FactoryAdded` in `ManagerCore.initialize`
- emit `UseAssetAllowlistUpdated` in `DelegatedManager.constructor`

Notes
- Refactored DelegatedManagerFactory tests to use `MockModule` to test initialization flows
- Added address zero checks to ManagerCore
- Added tests for event emissions on `DelegatedManager.constructor`
- Added `getLastBlockTransaction()` to testingUtils