### PR TITLE
Delegated manager system internal audit alternate [SIM-179]

### DIFF
--- a/contracts/factories/DelegatedManagerFactory.sol
+++ b/contracts/factories/DelegatedManagerFactory.sol
@@ -243,7 +243,7 @@ contract DelegatedManagerFactory {
 
         for (uint256 i = 0; i < _initializeTargets.length; i++) {
             address target = _initializeTargets[i];
-            require(!controller.isSet(target), "Target must not be SetToken");
+            require(controller.isModule(target) || managerCore.isExtension(target), "Target must be module or extension");
 
             // Because we validate uniqueness of _initializeTargets only one transaction can be sent to each module or extension during this
             // transaction. Due to this no modules/extension can be used for any SetToken transactions other than initializing these contracts

--- a/contracts/interfaces/IManagerCore.sol
+++ b/contracts/interfaces/IManagerCore.sol
@@ -19,6 +19,7 @@ pragma solidity 0.6.10;
 
 interface IManagerCore {
     function addManager(address _manager) external;
-    function isManager(address _manager) external view returns(bool);
+    function isExtension(address _extension) external view returns(bool);
     function isFactory(address _factory) external view returns(bool);
+    function isManager(address _manager) external view returns(bool);
 }

--- a/test/extensions/issuanceExtension.spec.ts
+++ b/test/extensions/issuanceExtension.spec.ts
@@ -98,7 +98,7 @@ describe("IssuanceExtension", () => {
 
     await setToken.setManager(delegatedManager.address);
 
-    await managerCore.initialize([factory.address]);
+    await managerCore.initialize([issuanceExtension.address], [factory.address]);
     await managerCore.connect(factory.wallet).addManager(delegatedManager.address);
 
     maxManagerFee = ether(.1);

--- a/test/extensions/streamingFeeSplitExtension.spec.ts
+++ b/test/extensions/streamingFeeSplitExtension.spec.ts
@@ -102,7 +102,7 @@ describe("StreamingFeeSplitExtension", () => {
 
     await setToken.setManager(delegatedManager.address);
 
-    await managerCore.initialize([factory.address]);
+    await managerCore.initialize([streamingFeeSplitExtension.address], [factory.address]);
     await managerCore.connect(factory.wallet).addManager(delegatedManager.address);
 
     feeRecipient = delegatedManager.address;

--- a/test/extensions/tradeExtension.spec.ts
+++ b/test/extensions/tradeExtension.spec.ts
@@ -96,7 +96,7 @@ describe("TradeExtension", () => {
 
     await setToken.setManager(delegatedManager.address);
 
-    await managerCore.initialize([factory.address]);
+    await managerCore.initialize([tradeExtension.address], [factory.address]);
     await managerCore.connect(factory.wallet).addManager(delegatedManager.address);
   });
 

--- a/test/factories/delegatedManagerFactory.spec.ts
+++ b/test/factories/delegatedManagerFactory.spec.ts
@@ -74,7 +74,7 @@ describe("DelegatedManagerFactory", () => {
       setV2Setup.factory.address
     );
 
-    await managerCore.initialize([delegatedManagerFactory.address]);
+    await managerCore.initialize([mockFeeExtension.address, mockIssuanceExtension.address], [delegatedManagerFactory.address]);
   });
 
   // Helper function to run a setup execution of either `createSetAndManager` or `createManager`

--- a/test/lib/baseGlobalExtension.spec.ts
+++ b/test/lib/baseGlobalExtension.spec.ts
@@ -93,7 +93,7 @@ describe("BaseGlobalExtension", () => {
     // Transfer ownership to DelegatedManager
     await setToken.setManager(delegatedManager.address);
 
-    await managerCore.initialize([factory.address]);
+    await managerCore.initialize([baseExtensionMock.address], [factory.address]);
     await managerCore.connect(factory.wallet).addManager(delegatedManager.address);
 
     await baseExtensionMock.initializeExtension(delegatedManager.address);

--- a/test/manager/delegatedManager.spec.ts
+++ b/test/manager/delegatedManager.spec.ts
@@ -93,7 +93,7 @@ describe("DelegatedManager", () => {
     // Transfer ownership to DelegatedManager
     await setToken.setManager(delegatedManager.address);
 
-    await managerCore.initialize([factory.address]);
+    await managerCore.initialize([baseExtension.address], [factory.address]);
     await managerCore.connect(factory.wallet).addManager(delegatedManager.address);
   });
 


### PR DESCRIPTION
Instead of calling `Extension.initializeModuleAndExtension` in the factory migration flow, call `Module.initialize` or `Extension.initializeExtension` to get over Manager issue #23 

Notes
- Track `extensions` on `ManagerCore`
- Make sure targets in `DelegatedManagerFactory.initialize()` are ManagerCore-tracked `extensions` or Controller-tracked `modules`

To do
- Check first argument of `_initializeBytecode` to be the `SetToken` in case of `Module.initialize` and `DelegatedManager` in case of `Extension.initialize`