### PR TITLE
Natspec fixes for DelegatedManager and TradeExtension

### DIFF
--- a/contracts/extensions/TradeExtension.sol
+++ b/contracts/extensions/TradeExtension.sol
@@ -1,14 +1,18 @@
 /*
     Copyright 2022 Set Labs Inc.
+
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
+
     http://www.apache.org/licenses/LICENSE-2.0
+
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,
     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
     See the License for the specific language governing permissions and
     limitations under the License.
+
     SPDX-License-Identifier: Apache License, Version 2.0
 */
 

--- a/contracts/manager/DelegatedManager.sol
+++ b/contracts/manager/DelegatedManager.sol
@@ -325,7 +325,8 @@ contract DelegatedManager is Ownable, MutualUpgradeV2 {
     }
 
     /**
-     * ONLY OWNER: Update percent of fees that are sent to owner
+     * MUTUAL UPGRADE: Update percent of fees that are sent to owner. Owner and Methodologist must each call this function to execute
+     * the update. If Owner and Methodologist point to the same address, the update can be executed in a single call.
      *
      * @param _newFeeSplit           Percent in precise units (100% = 10**18) of fees that accrue to owner
      */


### PR DESCRIPTION
Notes
- Specifies `mutualUpgrade` on `DelegatedManager.updateOwnerFeeSplit` natspec
- Nit: adds line spaces in `TradeExtension` header
