### PR TITLE
fix(basis trading strategy contract): Update engage requirement

### DIFF
--- a/contracts/extensions/DeltaNeutralBasisTradingStrategyExtension.sol
+++ b/contracts/extensions/DeltaNeutralBasisTradingStrategyExtension.sol
@@ -1152,7 +1152,11 @@ contract DeltaNeutralBasisTradingStrategyExtension is BaseExtension {
     function _getAndValidateEngageInfo() internal view returns(LeverageInfo memory) {
         ActionInfo memory engageInfo = _createActionInfo();
 
-        require(engageInfo.accountInfo.collateralBalance == 0, "PerpV2 collateral balance must be 0");
+        // Check that there is zero position unit of USDC of collateral value. Allows to neglect dust amounts.
+        require(
+            engageInfo.accountInfo.collateralBalance.preciseDiv(engageInfo.setTotalSupply.toInt256()) == 0,
+            "PerpV2 collateral balance must be 0"
+        );
 
         return LeverageInfo({
             action: engageInfo,


### PR DESCRIPTION
#### Bug
This [engage transaction](https://kovan-optimistic.etherscan.io/tx/0xc0d35ea24f46c01b89f430197f8183b327ce1906aad8767508d43781318657cb) fails after the Set has been [disengage previously](https://kovan-optimistic.etherscan.io/tx/0xd13b188016ad14c8d69496527b7248c0c804b930566cd1cb67d811fa8d4d4566).

#### Solution
Update the require check to check that there is zero position unit of USDC of collateral value. Checking posiiton units allows us to neglect dust amounts.