### PR TITLE
fix(BasisTradingStrategy): Increase reinvest threshold amount 

### DIFF
--- a/contracts/extensions/DeltaNeutralBasisTradingStrategyExtension.sol
+++ b/contracts/extensions/DeltaNeutralBasisTradingStrategyExtension.sol
@@ -128,8 +128,9 @@ contract DeltaNeutralBasisTradingStrategyExtension is BaseExtension {
         uint256 rebalanceInterval;                      // Period of time required since last rebalance timestamp in seconds
         uint256 reinvestInterval;                       // Period of time required since last reinvestment timestamp in seconds
         uint256 minReinvestUnits;                       // Minimum reinvestment amount per Set at which `shouldRebalance` returns 4 (`ShouldRebalance.REINVEST`)
-                                                        // provided the reinvest interval has elaspsed. This threshold helps to avoid weird rounding errors that
-                                                        // can happen while reinvesting very small amounts. In collateral decimals (10e6 for USDC)
+                                                        // provided the reinvest interval has elapsed. This threshold helps to avoid weird rounding errors that
+                                                        // can happen while reinvesting very small amounts and helps the methodologist to not waste gas on reinvesting
+                                                        // very small amounts. In collateral decimals (10e6 for USDC).
 
     }
 

--- a/contracts/extensions/DeltaNeutralBasisTradingStrategyExtension.sol
+++ b/contracts/extensions/DeltaNeutralBasisTradingStrategyExtension.sol
@@ -1386,9 +1386,11 @@ contract DeltaNeutralBasisTradingStrategyExtension is BaseExtension {
         //   `reinvest()` transaction is mined.
         if (block.timestamp.sub(lastReinvestTimestamp) > methodology.reinvestInterval) {
             uint256 reinvestmentNotional = strategy.basisTradingModule.getUpdatedSettledFunding(strategy.setToken);
+            uint256 setTotalSupply = strategy.setToken.totalSupply();
 
-            // Reinvest only if reinvestment amount is greater than 1 wei worth of USDC (to account for rounding errors)
-            if (reinvestmentNotional.fromPreciseUnitToDecimals(collateralDecimals) > 1) {
+            // Reinvestment often occurs with very small amounts which lead to edge case rounding errors
+            // Reinvest only if amount is greater than 10 wei position units worth of USDC to avoid weird rounding errors during reinvest
+            if (reinvestmentNotional.fromPreciseUnitToDecimals(collateralDecimals).preciesDiv(setTotalSupply) > 10) {
                 return ShouldRebalance.REINVEST;
             }
         }

--- a/contracts/extensions/DeltaNeutralBasisTradingStrategyExtension.sol
+++ b/contracts/extensions/DeltaNeutralBasisTradingStrategyExtension.sol
@@ -1388,9 +1388,9 @@ contract DeltaNeutralBasisTradingStrategyExtension is BaseExtension {
             uint256 reinvestmentNotional = strategy.basisTradingModule.getUpdatedSettledFunding(strategy.setToken);
             uint256 setTotalSupply = strategy.setToken.totalSupply();
 
-            // Reinvestment often occurs with very small amounts which lead to edge case rounding errors
+            // Reinvestment often occurs with very small amounts which leads to edge case rounding errors.
             // Reinvest only if amount is greater than 10 wei position units worth of USDC to avoid weird rounding errors during reinvest
-            if (reinvestmentNotional.fromPreciseUnitToDecimals(collateralDecimals).preciesDiv(setTotalSupply) > 10) {
+            if (reinvestmentNotional.fromPreciseUnitToDecimals(collateralDecimals).preciseDiv(setTotalSupply) > 10) {
                 return ShouldRebalance.REINVEST;
             }
         }

--- a/contracts/extensions/DeltaNeutralBasisTradingStrategyExtension.sol
+++ b/contracts/extensions/DeltaNeutralBasisTradingStrategyExtension.sol
@@ -208,7 +208,8 @@ contract DeltaNeutralBasisTradingStrategyExtension is BaseExtension {
         int256 _maxLeverageRatio,
         uint256 _recenteringSpeed,
         uint256 _rebalanceInterval,
-        uint256 _reinvestInterval
+        uint256 _reinvestInterval,
+        uint256 _minReinvestUnits
     );
     event ExecutionSettingsUpdated(
         uint256 _twapCooldownPeriod,
@@ -533,7 +534,8 @@ contract DeltaNeutralBasisTradingStrategyExtension is BaseExtension {
             methodology.maxLeverageRatio,
             methodology.recenteringSpeed,
             methodology.rebalanceInterval,
-            methodology.reinvestInterval
+            methodology.reinvestInterval,
+            methodology.minReinvestUnits
         );
     }
 
@@ -1393,7 +1395,7 @@ contract DeltaNeutralBasisTradingStrategyExtension is BaseExtension {
             uint256 setTotalSupply = strategy.setToken.totalSupply();
             uint256 reinvestUnits = reinvestmentNotional.fromPreciseUnitToDecimals(collateralDecimals).preciseDiv(setTotalSupply);
 
-            if (reinvestUnits > methodology.minReinvestUnits) {
+            if (reinvestUnits >= methodology.minReinvestUnits) {
                 return ShouldRebalance.REINVEST;
             }
         }
@@ -1432,6 +1434,7 @@ contract DeltaNeutralBasisTradingStrategyExtension is BaseExtension {
             _methodology.recenteringSpeed <= PreciseUnitMath.preciseUnit() && _methodology.recenteringSpeed > 0,
             "Must be valid recentering speed"
         );
+        require(_methodology.minReinvestUnits > 0, "Must be valid min reinvest units");
         require (
             _execution.slippageTolerance <= PreciseUnitMath.preciseUnit(),
             "Slippage tolerance must be <100%"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@setprotocol/set-v2-strategies",
-  "version": "0.0.9-basis.0",
+  "version": "0.0.10",
   "description": "",
   "main": "dist",
   "types": "dist/types",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@setprotocol/set-v2-strategies",
-  "version": "0.0.9",
+  "version": "0.0.9-basis.0",
   "description": "",
   "main": "dist",
   "types": "dist/types",

--- a/test/extensions/deltaNeutralBasisTradingStrategyExtension.spec.ts
+++ b/test/extensions/deltaNeutralBasisTradingStrategyExtension.spec.ts
@@ -2654,8 +2654,22 @@ describe("DeltaNeutralBasisTradingStrategyExtension", () => {
             subjectMethodologySettings.maxLeverageRatio,
             subjectMethodologySettings.recenteringSpeed,
             subjectMethodologySettings.rebalanceInterval,
-            subjectMethodologySettings.reinvestInterval
+            subjectMethodologySettings.reinvestInterval,
+            subjectMethodologySettings.minReinvestUnits
           );
+        });
+
+        describe("when min reinvest units is zero", async () => {
+          beforeEach(async () => {
+            subjectMethodologySettings = {
+              ...subjectMethodologySettings,
+              minReinvestUnits: ZERO
+            };
+          });
+
+          it("should revert", async () => {
+            await expect(subject()).to.be.revertedWith("Must be valid min reinvest units");
+          });
         });
 
         describe("when the caller is not the operator", async () => {

--- a/test/extensions/deltaNeutralBasisTradingStrategyExtension.spec.ts
+++ b/test/extensions/deltaNeutralBasisTradingStrategyExtension.spec.ts
@@ -250,6 +250,7 @@ describe("DeltaNeutralBasisTradingStrategyExtension", () => {
     const recenteringSpeed = ether(0.05);
     const rebalanceInterval = ONE_DAY_IN_SECONDS;
     const reinvestInterval = ONE_DAY_IN_SECONDS.mul(7);
+    const minReinvestUnits = TWO;
 
     const exchangeName = "UniswapV3ExchangeAdapterV2";
     const buyExactSpotTradeData = await uniswapV3ExchangeAdapter.generateDataParam(
@@ -295,7 +296,8 @@ describe("DeltaNeutralBasisTradingStrategyExtension", () => {
       maxLeverageRatio: maxLeverageRatio,
       recenteringSpeed: recenteringSpeed,
       rebalanceInterval: rebalanceInterval,
-      reinvestInterval: reinvestInterval
+      reinvestInterval: reinvestInterval,
+      minReinvestUnits: minReinvestUnits
     };
     execution = {
       twapCooldownPeriod: twapCooldownPeriod,
@@ -365,7 +367,8 @@ describe("DeltaNeutralBasisTradingStrategyExtension", () => {
         maxLeverageRatio: ether(-1.3),
         recenteringSpeed: ether(0.05),
         rebalanceInterval: BigNumber.from(86400),
-        reinvestInterval: ONE_DAY_IN_SECONDS.mul(7)
+        reinvestInterval: ONE_DAY_IN_SECONDS.mul(7),
+        minReinvestUnits: TWO
       };
       subjectExecutionSettings = {
         twapCooldownPeriod: BigNumber.from(120),
@@ -2617,7 +2620,8 @@ describe("DeltaNeutralBasisTradingStrategyExtension", () => {
           maxLeverageRatio: ether(-1.1),
           recenteringSpeed: ether(0.1),
           rebalanceInterval: BigNumber.from(43200),
-          reinvestInterval: ONE_DAY_IN_SECONDS.mul(7)
+          reinvestInterval: ONE_DAY_IN_SECONDS.mul(7),
+          minReinvestUnits: TWO
         };
         subjectCaller = owner;
       };
@@ -3513,7 +3517,7 @@ describe("DeltaNeutralBasisTradingStrategyExtension", () => {
             });
           });
 
-          describe("when reinvestment amount is zero", async () => {
+          describe("when reinvestment amount is below threshold", async () => {
             beforeEach(async () => {
               // Set oracle price above mark price to accrue negative funding
               await perpV2Setup.setBaseTokenOraclePrice(perpV2Setup.vETH, usdc(1020));
@@ -3828,7 +3832,7 @@ describe("DeltaNeutralBasisTradingStrategyExtension", () => {
             });
           });
 
-          describe("when reinvestment amount is zero", async () => {
+          describe("when reinvestment amount is below threshold", async () => {
             beforeEach(async () => {
               // Set oracle price above mark price to accrue negative funding
               await perpV2Setup.setBaseTokenOraclePrice(perpV2Setup.vETH, usdc(1020));

--- a/utils/types.ts
+++ b/utils/types.ts
@@ -90,6 +90,7 @@ export interface PerpV2BasisMethodologySettings {
   recenteringSpeed: BigNumber;
   rebalanceInterval: BigNumber;
   reinvestInterval: BigNumber;
+  minReinvestUnits: BigNumber;
 }
 
 export interface PerpV2BasisExecutionSettings {


### PR DESCRIPTION
Reinvestment often occurs with very small amounts which leads to edge case rounding errors while calculating position units.
For example, in this [transaction](https://optimistic.etherscan.io/tx/0x8b2768780df99f966923becfa47d3b45ce209c0dbfbbed1ac7b2ae522f9ad20b), reinvest notional amount is 22 wei (22 * 10^-6 USDC) when total supply is 11.065. During reinvest, we calculate spot reinvest amount = 22 * 0.5 = 11, spotReinvestUnits = 11 / 11.065 = 1 (rounded up). But during deposit, 11 / 11.065 = 0 (rounded down), and depositing 0 units isn't allowed by the module.

### Solution
Add a configurable min reinvestment units parameter to determine the threshold amount above which `shouldRebalance` would return `reinvest` provided the reinvest interval has elapsed. This parameter serves two purposes:
1. This threshold helps to avoid weird rounding errors that can happen while reinvesting very small amounts.
2. It allows the methodologist to not waste gas on reinvesting very small amounts.

### Suggestions for setting the `minReinvestUnits` methodology param
- For leverage ratio > |1|, minReinvestUnit should be at least 2 wei for no rounding errors. In this case, first we use 1 wei to trade on dex and then deposit the rest 1 wei to PerpV2.
- For leverage ratio = |0.5|, minReinvestUnit should be at least 4 for no rounding errors.
- A [successful reinvest](https://optimistic.etherscan.io/tx/6022368) costs around 39 cents, so practically we should be reinvesting an amount higher than that. If the total supply is x, then minReinvestUnits should be set to roughly (390000 * x) wei.

### Todo
- [x] Update package before merge