### PR TITLE
Add BatchTrading intergration tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -121,6 +121,7 @@ jobs:
     steps:
       - attach_workspace:
           at: /tmp/coverage
+      - attach_workspace:
           at: /tmp/forked_coverage
       - restore_cache:
           key: compiled-env-{{ .Environment.CIRCLE_SHA1 }}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -62,19 +62,19 @@ jobs:
           command: cp .env.default .env
       - run:
           name: Create shared coverage outputs folder
-          command: mkdir -p /tmp/coverage
+          command: mkdir -p /tmp/forked_coverage
       - run:
           name: Hardhat Test
           command: yarn test:fork:coverage
       - run:
           name: Save coverage
           command: |
-            cp coverage.json /tmp/coverage/cov_forked_0.json
-            chmod -R 777 /tmp/coverage/cov_forked_0.json
+            cp coverage.json /tmp/forked_coverage/forked_cov.json
+            chmod -R 777 /tmp/forked_coverage/forked_cov.json
       - persist_to_workspace:
-          root: /tmp/coverage
+          root: /tmp/forked_coverage
           paths:
-            - cov_forked_0.json
+            - forked_cov.json
 
   coverage:
     docker:
@@ -121,19 +121,21 @@ jobs:
     steps:
       - attach_workspace:
           at: /tmp/coverage
+          at: /tmp/forked_coverage
       - restore_cache:
           key: compiled-env-{{ .Environment.CIRCLE_SHA1 }}
       - run:
           name: Combine coverage reports
           command: |
             cp -R /tmp/coverage/* .
+            cp -R /tmp/forked_coverage/* .
             npx istanbul-combine-updated -r lcov \
               cov_0.json \
               cov_1.json \
               cov_2.json \
               cov_3.json \
               cov_4.json \
-              cov_forked_0.json
+              forked_cov.json
       - run:
           name: Upload coverage
           command: |
@@ -156,3 +158,4 @@ workflows:
       - report_coverage:
           requires:
             - coverage
+            - test_forked_network

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -61,8 +61,20 @@ jobs:
           name: Set Up Environment Variables
           command: cp .env.default .env
       - run:
+          name: Create shared coverage outputs folder
+          command: mkdir -p /tmp/coverage
+      - run:
           name: Hardhat Test
           command: yarn test:fork
+      - run:
+          name: Save coverage
+          command: |
+            cp coverage.json /tmp/coverage/cov_forked_0.json
+            chmod -R 777 /tmp/coverage/cov_forked_0.json
+      - persist_to_workspace:
+          root: /tmp/coverage
+          paths:
+            - cov_forked_0.json
 
   coverage:
     docker:
@@ -120,7 +132,8 @@ jobs:
               cov_1.json \
               cov_2.json \
               cov_3.json \
-              cov_4.json
+              cov_4.json \
+              cov_forked_0.json
       - run:
           name: Upload coverage
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -65,7 +65,7 @@ jobs:
           command: mkdir -p /tmp/coverage
       - run:
           name: Hardhat Test
-          command: yarn test:fork
+          command: yarn test:fork:coverage
       - run:
           name: Save coverage
           command: |

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "prepare": "yarn build",
     "prepublishOnly": "yarn clean && yarn build:npm",
     "test": "npx hardhat test --network localhost",
+    "test:fork:coverage": "FORK=true COVERAGE=true npx hardhat coverage",
     "test:fork": "FORK=true npx hardhat test",
     "test:fork:fast": "NO_COMPILE=true TS_NODE_TRANSPILE_ONLY=1 FORK=true npx hardhat test --no-compile",
     "test:clean": "yarn clean && yarn build && yarn test",

--- a/test/extensions/batchTradeExtension.spec.ts
+++ b/test/extensions/batchTradeExtension.spec.ts
@@ -553,7 +553,7 @@ describe("BatchTradeExtension", () => {
       });
 
       it("should emit the correct TradeFailed event", async () => {
-        await expect(subject()).to.emit(batchTradeExtension, "TradeFailed").withArgs(
+        await expect(subject()).to.emit(batchTradeExtension, "StringTradeFailed").withArgs(
           setToken.address,
           1,
           "Insufficient funds in exchange"

--- a/test/integration/batchTradeExtensionZeroEx.spec.ts
+++ b/test/integration/batchTradeExtensionZeroEx.spec.ts
@@ -1,0 +1,370 @@
+import "module-alias/register";
+
+import { BigNumber, ContractTransaction } from "ethers";
+import { ethers } from "hardhat";
+
+import { Address, Account, TradeInfo } from "@utils/types";
+import { ZERO, ADDRESS_ZERO } from "@utils/constants";
+import DeployHelper from "@utils/deploys";
+
+// Strategies
+import {
+  DelegatedManager,
+  BatchTradeExtension,
+  ManagerCore,
+} from "@utils/contracts/index";
+import {
+  ether,
+  bitcoin,
+  preciseMul,
+  cacheBeforeEach,
+  getAccounts,
+  getWaffleExpect
+} from "@utils/index";
+import {
+  BatchTradeUtils
+} from "@utils/common";
+
+// SetProtocol
+import dependencies from "@setprotocol/set-protocol-v2/dist/utils/deploys/dependencies";
+import {
+  SetToken,
+  TradeModule,
+  BasicIssuanceModule,
+  ZeroExApiAdapter,
+} from "@setprotocol/set-protocol-v2/utils/contracts";
+import {
+  getSystemFixture,
+  getForkedTokens,
+  initializeForkedTokens,
+  ForkedTokens
+} from "@setprotocol/set-protocol-v2/dist/utils/test";
+import {
+  SystemFixture
+} from "@setprotocol/set-protocol-v2/dist/utils/fixtures";
+
+import { inspect } from "util";
+
+const expect = getWaffleExpect();
+
+describe("BatchTradeExtension - ZeroExAPITradeAdapter - TradeModule Integration [ @forked-mainnet ]", () => {
+  let owner: Account;
+  let methodologist: Account;
+  let operator: Account;
+  let factory: Account;
+
+  let deployer: DeployHelper;
+
+  let zeroExApiAdapter: ZeroExApiAdapter;
+  let zeroExApiAdapterName: string;
+
+  let setToken: SetToken;
+  let managerCore: ManagerCore;
+  let delegatedManager: DelegatedManager;
+  let batchTradeExtension: BatchTradeExtension;
+  let batchTradeUtils: BatchTradeUtils;
+
+  let setV2Setup: SystemFixture;
+  let zeroExAddress: Address;
+  let tradeModule: TradeModule;
+  let issuanceModule: BasicIssuanceModule;
+  let tokens: ForkedTokens;
+  let daiWeight: BigNumber;
+  let wethWeight: BigNumber;
+  let wbtcWeight: BigNumber;
+  let totalSupply: BigNumber;
+
+  cacheBeforeEach(async () => {
+    [
+      owner,
+      methodologist,
+      operator,
+      factory
+    ] = await getAccounts();
+
+    deployer = new DeployHelper(owner.wallet);
+    setV2Setup = getSystemFixture(owner.address);
+    batchTradeUtils = new BatchTradeUtils(ethers.provider);
+    await setV2Setup.initialize();
+
+    // Set variables
+    issuanceModule = setV2Setup.issuanceModule;
+    zeroExAddress = dependencies.ZERO_EX_EXCHANGE["1"];
+
+    // Get forked tokens and fund owner so they can create an initial issuance
+    tokens = getForkedTokens();
+    await initializeForkedTokens(deployer.setDeployer);
+
+    // Deploy ZeroExApiAdapter
+    zeroExApiAdapter = await deployer
+      .setDeployer
+      .adapters
+      .deployZeroExApiAdapter(zeroExAddress, tokens.weth.address);
+
+    zeroExApiAdapterName = "ZeroExApiAdapterV5";
+
+    // Deploy TradeModule and wire up with ZeroExApiAdapter
+    tradeModule = await deployer.setDeployer.modules.deployTradeModule(setV2Setup.controller.address);
+    await setV2Setup.controller.addModule(tradeModule.address);
+
+    await setV2Setup.integrationRegistry.addIntegration(
+      tradeModule.address,
+      zeroExApiAdapterName,
+      zeroExApiAdapter.address
+    );
+
+    // Deploy and issue 1 SetToken
+    // BED-like: each token has ~1/3 weight
+    daiWeight = ether(35);
+    wethWeight = ether(.012099);
+    wbtcWeight = bitcoin(.000913);
+
+    setToken = await setV2Setup.createSetToken(
+      [tokens.dai.address, tokens.weth.address, tokens.wbtc.address],
+      [daiWeight, wethWeight, wbtcWeight],
+      [setV2Setup.issuanceModule.address, tradeModule.address]
+    );
+
+    await tradeModule.connect(owner.wallet).initialize(setToken.address);
+    await issuanceModule.connect(owner.wallet).initialize(setToken.address, ADDRESS_ZERO);
+
+    await tokens.dai.transfer(owner.address, daiWeight.mul(100));
+    await tokens.weth.transfer(owner.address, wethWeight.mul(100));
+    await tokens.wbtc.transfer(owner.address, wbtcWeight.mul(100));
+
+    await tokens.dai.connect(owner.wallet).approve(issuanceModule.address, ethers.constants.MaxUint256);
+    await tokens.weth.connect(owner.wallet).approve(issuanceModule.address, ethers.constants.MaxUint256);
+    await tokens.wbtc.connect(owner.wallet).approve(issuanceModule.address, ethers.constants.MaxUint256);
+
+    await setV2Setup.issuanceModule.issue(setToken.address, ether(1), owner.address);
+    totalSupply = await setToken.totalSupply();
+
+    // Deploy DelegatedManager with BatchTradeExtension and transfer SetToken managership to it
+    managerCore = await deployer.managerCore.deployManagerCore();
+
+    batchTradeExtension = await deployer.globalExtensions.deployBatchTradeExtension(
+      managerCore.address,
+      tradeModule.address
+    );
+
+    delegatedManager = await deployer.manager.deployDelegatedManager(
+      setToken.address,
+      factory.address,
+      methodologist.address,
+      [batchTradeExtension.address],
+      [operator.address],
+      [tokens.dai.address, tokens.weth.address, tokens.wbtc.address],
+      true
+    );
+
+    await setToken.setManager(delegatedManager.address);
+
+    await managerCore.initialize([batchTradeExtension.address], [factory.address]);
+    await managerCore.connect(factory.wallet).addManager(delegatedManager.address);
+    await batchTradeExtension.connect(owner.wallet).initializeExtension(delegatedManager.address);
+  });
+
+  describe("#batchTrade", function() {
+    let quoteSlippage: number;
+    let subjectSetToken: Address;
+    let subjectTradeOne: TradeInfo;
+    let subjectTradeTwo: TradeInfo;
+    let subjectTrades: TradeInfo[];
+    let subjectCaller: Account;
+
+    async function subject(): Promise<ContractTransaction> {
+      return batchTradeExtension.connect(subjectCaller.wallet).batchTrade(
+        subjectSetToken,
+        subjectTrades
+      );
+    }
+
+    context("when trading all dai and weth into wbtc", () => {
+      beforeEach(async () => {
+        const daiPositionUnit = await setToken.getDefaultPositionRealUnit(tokens.dai.address);
+        const wethPositionUnit = await setToken.getDefaultPositionRealUnit(tokens.weth.address);
+
+        const daiAmount = preciseMul(daiPositionUnit, totalSupply);
+        const wethAmount = preciseMul(wethPositionUnit, totalSupply);
+
+        quoteSlippage = .99; // Wide
+
+        const daiQuote = await batchTradeUtils.getZeroExQuote(
+          delegatedManager.address,
+          tokens.dai.address,
+          tokens.wbtc.address,
+          daiAmount,
+          quoteSlippage
+        );
+
+        const wethQuote = await batchTradeUtils.getZeroExQuote(
+          delegatedManager.address,
+          tokens.weth.address,
+          tokens.wbtc.address,
+          wethAmount,
+          quoteSlippage
+        );
+
+        subjectTradeOne = {
+          exchangeName: zeroExApiAdapterName,
+          sendToken: tokens.dai.address,
+          sendQuantity: daiPositionUnit,
+          receiveToken: tokens.wbtc.address,
+          minReceiveQuantity: ether(0),
+          data: daiQuote.data
+        } as TradeInfo;
+
+        subjectTradeTwo = {
+          exchangeName: zeroExApiAdapterName,
+          sendToken: tokens.weth.address,
+          sendQuantity: wethPositionUnit,
+          receiveToken: tokens.wbtc.address,
+          minReceiveQuantity: ether(0),
+          data: wethQuote.data
+        } as TradeInfo;
+
+        subjectTrades = [subjectTradeOne, subjectTradeTwo];
+        subjectSetToken = setToken.address;
+        subjectCaller = operator;
+      });
+
+      it("trades as expected", async () => {
+        const initialDaiDefaultPosition = await setToken.getDefaultPositionRealUnit(tokens.dai.address);
+        const initialWethDefaultPosition = await setToken.getDefaultPositionRealUnit(tokens.weth.address);
+        const initialWbtcDefaultPosition = await setToken.getDefaultPositionRealUnit(tokens.wbtc.address);
+
+        const result = await subject();
+
+        const finalDaiDefaultPosition = await setToken.getDefaultPositionRealUnit(tokens.dai.address);
+        const finalWethDefaultPosition = await setToken.getDefaultPositionRealUnit(tokens.weth.address);
+        const finalWbtcDefaultPosition = await setToken.getDefaultPositionRealUnit(tokens.wbtc.address);
+
+        const txs = await batchTradeUtils.getBatchTradeResults(
+          batchTradeExtension,
+          result.hash,
+          subjectTrades,
+        );
+
+        expect(txs[0].success).eq(true);
+        expect(txs[1].success).eq(true);
+
+        expect(initialDaiDefaultPosition).gt(ZERO);
+        expect(initialWethDefaultPosition).gt(ZERO);
+        expect(initialWbtcDefaultPosition).gt(ZERO);
+
+        expect(finalDaiDefaultPosition).eq(ZERO);
+        expect(finalWethDefaultPosition).eq(ZERO);
+        expect(finalWbtcDefaultPosition).gt(initialWbtcDefaultPosition);
+      });
+    });
+
+    context("when trading and triggering underbought error", () => {
+      beforeEach(async () => {
+        const daiPositionUnit = await setToken.getDefaultPositionRealUnit(tokens.dai.address);
+        const daiAmount = preciseMul(daiPositionUnit, totalSupply);
+
+        quoteSlippage = 0; // Narrow
+
+        const daiQuote = await batchTradeUtils.getZeroExQuote(
+          delegatedManager.address,
+          tokens.dai.address,
+          tokens.wbtc.address,
+          daiAmount,
+          quoteSlippage
+        );
+
+        subjectTradeOne = {
+          exchangeName: zeroExApiAdapterName,
+          sendToken: tokens.dai.address,
+          sendQuantity: daiPositionUnit,
+          receiveToken: tokens.wbtc.address,
+          minReceiveQuantity: ether(0),
+          data: daiQuote.data
+        } as TradeInfo;
+
+        subjectTrades = [subjectTradeOne];
+        subjectSetToken = setToken.address;
+        subjectCaller = operator;
+      });
+
+      it("trades as expected", async () => {
+        const initialDaiDefaultPosition = await setToken.getDefaultPositionRealUnit(tokens.dai.address);
+        const initialWbtcDefaultPosition = await setToken.getDefaultPositionRealUnit(tokens.wbtc.address);
+
+        const result = await subject();
+
+        const finalDaiDefaultPosition = await setToken.getDefaultPositionRealUnit(tokens.dai.address);
+        const finalWbtcDefaultPosition = await setToken.getDefaultPositionRealUnit(tokens.wbtc.address);
+
+        const txs = await batchTradeUtils.getBatchTradeResults(
+          batchTradeExtension,
+          result.hash,
+          subjectTrades,
+        );
+
+        // Verify that revert reason is human readable
+        expect(txs[0].success).eq(false);
+        expect(txs[0].revertReason!.length).gt(0);
+        expect(txs[0].revertReason!.slice(0,2)).not.eq("0x");
+
+        expect(finalDaiDefaultPosition).eq(initialDaiDefaultPosition);
+        expect(finalWbtcDefaultPosition).eq(initialWbtcDefaultPosition);
+      });
+    });
+
+    context("when trading and triggering a bytes error", () => {
+      beforeEach(async () => {
+        // Issue 70 sets
+        await setV2Setup.issuanceModule.issue(setToken.address, ether(70), owner.address);
+        totalSupply = await setToken.totalSupply();
+
+        const daiPositionUnit = await setToken.getDefaultPositionRealUnit(tokens.dai.address);
+        const daiAmount = preciseMul(daiPositionUnit, totalSupply);
+
+        quoteSlippage = .01; // Narrow
+
+        const daiQuote = await batchTradeUtils.getZeroExQuote(
+          delegatedManager.address,
+          tokens.dai.address,
+          tokens.wbtc.address,
+          daiAmount,
+          quoteSlippage
+        );
+
+        subjectTradeOne = {
+          exchangeName: zeroExApiAdapterName,
+          sendToken: tokens.dai.address,
+          sendQuantity: daiPositionUnit,
+          receiveToken: tokens.wbtc.address,
+          minReceiveQuantity: ether(0),
+          data: daiQuote.data
+        } as TradeInfo;
+
+        subjectTrades = [subjectTradeOne];
+        subjectSetToken = setToken.address;
+        subjectCaller = operator;
+      });
+
+      it("trades as expected", async () => {
+        const initialDaiDefaultPosition = await setToken.getDefaultPositionRealUnit(tokens.dai.address);
+        const initialWbtcDefaultPosition = await setToken.getDefaultPositionRealUnit(tokens.wbtc.address);
+
+        const result = await subject();
+
+        const finalDaiDefaultPosition = await setToken.getDefaultPositionRealUnit(tokens.dai.address);
+        const finalWbtcDefaultPosition = await setToken.getDefaultPositionRealUnit(tokens.wbtc.address);
+
+        const txs = await batchTradeUtils.getBatchTradeResults(
+          batchTradeExtension,
+          result.hash,
+          subjectTrades,
+        );
+
+        console.log("txs --> " + inspect(txs));
+        // revertReason: '0x734e6e1c6af479b200000000000000000000000000000000000000000000000000000000'
+        expect(finalDaiDefaultPosition).eq(initialDaiDefaultPosition);
+        expect(finalWbtcDefaultPosition).eq(initialWbtcDefaultPosition);
+      });
+    });
+  });
+});

--- a/utils/common/batchTradeUtils.ts
+++ b/utils/common/batchTradeUtils.ts
@@ -1,0 +1,91 @@
+import axios from "axios";
+import { providers, BigNumber } from "ethers";
+import { Address, TradeInfo, BatchTradeResult } from "@utils/types";
+import { BatchTradeExtension } from "../contracts/index";
+
+export class BatchTradeUtils {
+  public provider: providers.Web3Provider | providers.JsonRpcProvider;
+
+  constructor(_provider: providers.Web3Provider | providers.JsonRpcProvider) {
+    this.provider = _provider;
+  }
+
+  // Helper to fetch transaction statuses
+  public async getBatchTradeResults(
+    batchTradeInstance: BatchTradeExtension,
+    transactionHash: string,
+    trades: TradeInfo[]
+  ): Promise<BatchTradeResult[]> {
+
+    const receipt = await this.provider.getTransactionReceipt(transactionHash);
+    const results: BatchTradeResult[] = [];
+
+    for (const trade of trades) {
+      results.push({
+        success: true,
+        tradeInfo: trade,
+      });
+    }
+
+    for (const log of receipt.logs) {
+      try {
+        const decodedLog = batchTradeInstance.interface.parseLog({
+          data: log.data,
+          topics: log.topics,
+        });
+
+        if (decodedLog.name === "StringTradeFailed") {
+          console.log("StringTradeFailed");
+          const tradeIndex = (decodedLog.args as any)._index.toNumber();
+          results[tradeIndex].success = false;
+          results[tradeIndex].revertReason = (decodedLog.args as any)._reason;
+        }
+
+        // May need to do something extra here to decode low level revert bytes
+        if (decodedLog.name === "BytesTradeFailed") {
+          console.log("BytesTradeFailed");
+          const tradeIndex = (decodedLog.args as any)._index.toNumber();
+          results[tradeIndex].success = false;
+          results[tradeIndex].revertReason = (decodedLog.args as any)._reason;
+        }
+      } catch(e) {
+        // ignore all non-batch trade events
+      }
+    }
+
+    return results;
+  }
+
+  // Helper to fetch trade quotes from 0x
+  public async getZeroExQuote(
+    delegatedManager: Address,
+    sellToken: Address,
+    buyToken: Address,
+    amount: BigNumber,
+    slippagePercentage: number = .02 // Default to 2%
+  ) {
+    const url = "https://api.0x.org/swap/v1/quote";
+
+    const params = {
+      sellToken,
+      buyToken,
+      slippagePercentage,
+      sellAmount: amount.toString(),
+      takerAddress: delegatedManager,
+      excludedSources: [],
+      skipValidation: true,
+    };
+
+    const headers = {
+      "Content-Type": "application/json",
+      "Accept": "application/json",
+    };
+
+    const response = await axios.get(url, {
+      params,
+      headers,
+    });
+
+    return response.data;
+  }
+}

--- a/utils/common/batchTradeUtils.ts
+++ b/utils/common/batchTradeUtils.ts
@@ -35,15 +35,12 @@ export class BatchTradeUtils {
         });
 
         if (decodedLog.name === "StringTradeFailed") {
-          console.log("StringTradeFailed");
           const tradeIndex = (decodedLog.args as any)._index.toNumber();
           results[tradeIndex].success = false;
           results[tradeIndex].revertReason = (decodedLog.args as any)._reason;
         }
 
-        // May need to do something extra here to decode low level revert bytes
         if (decodedLog.name === "BytesTradeFailed") {
-          console.log("BytesTradeFailed");
           const tradeIndex = (decodedLog.args as any)._index.toNumber();
           results[tradeIndex].success = false;
           results[tradeIndex].revertReason = (decodedLog.args as any)._reason;

--- a/utils/common/index.ts
+++ b/utils/common/index.ts
@@ -12,6 +12,7 @@ export {
 export { bitcoin, ether, gWei, usdc, wbtc } from "./unitsUtils";
 export { Blockchain } from "./blockchainUtils";
 export { ProtocolUtils } from "./protocolUtils";
+export { BatchTradeUtils } from "./batchTradeUtils";
 export {
   convertLibraryNameToLinkId
 } from "./libraryUtils";

--- a/utils/types.ts
+++ b/utils/types.ts
@@ -128,3 +128,9 @@ export interface TradeInfo {
   minReceiveQuantity: BigNumber;
   data: Bytes;
 }
+
+export interface BatchTradeResult {
+  success: boolean;
+  tradeInfo: TradeInfo;
+  revertReason?: string | undefined;
+};


### PR DESCRIPTION
PR:
+ Adds forked mainnet tests using 0x quote API, TradeModule and ZeroExAPIAdapterV5
+ Restores bytes error catching - 0x is throwing custom errors which need to be caught there.

If we don't catch, the whole trade transaction reverts with:
```
Error: VM Exception while processing transaction: reverted with an unrecognized custom error
      at BatchTradeExtension.batchTrade (contracts/extensions/BatchTradeExtension.sol:176)
```