### PR TITLE
fix(BatchTradeExtension): BatchTradeExtension audit fixes [SIM-269]

### DIFF
--- a/contracts/extensions/BatchTradeExtension.sol
+++ b/contracts/extensions/BatchTradeExtension.sol
@@ -30,8 +30,8 @@ import { IManagerCore } from "../interfaces/IManagerCore.sol";
  * @title BatchTradeExtension
  * @author Set Protocol
  *
- * Smart contract global extension which provides DelegatedManager privileged operator(s) the ability to execute a
- * batch of trade on a DEX and the owner the ability to restrict operator(s) permissions with an asset whitelist.
+ * Smart contract global extension which provides DelegatedManager operator(s) the ability to execute a batch of trades
+ * on a DEX and the owner the ability to restrict operator(s) permissions with an asset whitelist.
  */
 contract BatchTradeExtension is BaseGlobalExtension {
 
@@ -40,29 +40,29 @@ contract BatchTradeExtension is BaseGlobalExtension {
     struct TradeInfo {
         string exchangeName;             // Human readable name of the exchange in the integrations registry
         address sendToken;               // Address of the token to be sent to the exchange
-        uint256 sendQuantity;            // Units of token in SetToken sent to the exchange
+        uint256 sendQuantity;            // Max units of `sendToken` sent to the exchange
         address receiveToken;            // Address of the token that will be received from the exchange
-        uint256 minReceiveQuantity;      // Min units of token in SetToken to be received from the exchange
+        uint256 receiveQuantity;         // Min units of `receiveToken` to be received from the exchange
         bytes data;                      // Arbitrary bytes to be used to construct trade call data
     }
 
     /* ============ Events ============ */
 
     event BatchTradeExtensionInitialized(
-        address indexed _setToken,
-        address indexed _delegatedManager
+        address indexed _setToken,                 // Address of the SetToken which had BatchTradeExtension initialized on their manager
+        address indexed _delegatedManager          // Address of the DelegatedManager which initialized the BatchTradeExtension
     );
 
     event StringTradeFailed(
-        address indexed _setToken,       // SetToken which failed trade targeted
-        uint256 _index,                  // Index of trade that failed in _trades parameter of batchTrade call
-        string _reason                   // String reason for the failure
+        address indexed _setToken,       // Address of the SetToken which the failed trade targeted
+        uint256 indexed _index,          // Index of trade that failed in _trades parameter of batchTrade call
+        string _reason                   // String reason for the trade failure
     );
 
     event BytesTradeFailed(
-        address indexed _setToken,       // SetToken which failed trade targeted
-        uint256 _index,                  // Index of trade that failed in _trades parameter of batchTrade call
-        bytes _reason                    // Custom error bytes encoding reason for failure
+        address indexed _setToken,       // Address of the SetToken which the failed trade targeted
+        uint256 indexed _index,          // Index of trade that failed in _trades parameter of batchTrade call
+        bytes _lowLevelData              // Bytes low level data reason for the trade failure
     );
 
     /* ============ State Variables ============ */
@@ -70,20 +70,14 @@ contract BatchTradeExtension is BaseGlobalExtension {
     // Instance of TradeModule
     ITradeModule public immutable tradeModule;
 
-    /* ============ Modifiers ============ */
-
-    /**
-     * Throws if any assets are not allowed to be held by the Set
-     */
-    modifier onlyAllowedAssets(ISetToken _setToken, TradeInfo[] memory _trades) {
-        for(uint256 i = 0; i < _trades.length; i++) {
-            require(_manager(_setToken).isAllowedAsset(_trades[i].receiveToken), "Must be allowed asset");
-        }
-        _;
-    }
-
     /* ============ Constructor ============ */
 
+    /**
+     * Instantiate with ManagerCore and TradeModule addresses.
+     *
+     * @param _managerCore              Address of ManagerCore contract
+     * @param _tradeModule              Address of TradeModule contract
+     */
     constructor(
         IManagerCore _managerCore,
         ITradeModule _tradeModule
@@ -102,8 +96,6 @@ contract BatchTradeExtension is BaseGlobalExtension {
      * @param _delegatedManager     Instance of the DelegatedManager to initialize the TradeModule for
      */
     function initializeModule(IDelegatedManager _delegatedManager) external onlyOwnerAndValidManager(_delegatedManager) {
-        require(_delegatedManager.isInitializedExtension(address(this)), "Extension must be initialized");
-
         _initializeModule(_delegatedManager.setToken(), _delegatedManager);
     }
 
@@ -113,8 +105,6 @@ contract BatchTradeExtension is BaseGlobalExtension {
      * @param _delegatedManager     Instance of the DelegatedManager to initialize
      */
     function initializeExtension(IDelegatedManager _delegatedManager) external onlyOwnerAndValidManager(_delegatedManager) {
-        require(_delegatedManager.isPendingExtension(address(this)), "Extension must be pending");
-
         ISetToken setToken = _delegatedManager.setToken();
 
         _initializeExtension(setToken, _delegatedManager);
@@ -123,13 +113,11 @@ contract BatchTradeExtension is BaseGlobalExtension {
     }
 
     /**
-     * ONLY OWNER: Initializes TradeExtension to the DelegatedManager and TradeModule to the SetToken
+     * ONLY OWNER: Initializes BatchTradeExtension to the DelegatedManager and TradeModule to the SetToken
      *
      * @param _delegatedManager     Instance of the DelegatedManager to initialize
      */
     function initializeModuleAndExtension(IDelegatedManager _delegatedManager) external onlyOwnerAndValidManager(_delegatedManager){
-        require(_delegatedManager.isPendingExtension(address(this)), "Extension must be pending");
-
         ISetToken setToken = _delegatedManager.setToken();
 
         _initializeExtension(setToken, _delegatedManager);
@@ -151,10 +139,10 @@ contract BatchTradeExtension is BaseGlobalExtension {
     /**
      * ONLY OPERATOR: Executes a batch of trades on a supported DEX. If any individual trades fail, events are emitted.
      * @dev Although the SetToken units are passed in for the send and receive quantities, the total quantity
-     * sent and received is the quantity of SetToken units multiplied by the SetToken totalSupply.
+     * sent and received is the quantity of component units multiplied by the SetToken totalSupply.
      *
      * @param _setToken             Instance of the SetToken to trade
-     * @param _trades               Struct of information for individual trades
+     * @param _trades               Array of TradeInfo structs containing information about trades
      */
     function batchTrade(
         ISetToken _setToken,
@@ -162,28 +150,31 @@ contract BatchTradeExtension is BaseGlobalExtension {
     )
         external
         onlyOperator(_setToken)
-        onlyAllowedAssets(_setToken, _trades)
     {
-        for(uint256 i = 0; i < _trades.length; i++) {
-            bytes memory callData = abi.encodeWithSignature(
-                "trade(address,string,address,uint256,address,uint256,bytes)",
+        uint256 tradesLength = _trades.length;
+        IDelegatedManager manager = _manager(_setToken);
+        for(uint256 i = 0; i < tradesLength; i++) {
+            require(manager.isAllowedAsset(_trades[i].receiveToken), "Must be allowed asset");
+
+            bytes memory callData = abi.encodeWithSelector(
+                ITradeModule.trade.selector,
                 _setToken,
                 _trades[i].exchangeName,
                 _trades[i].sendToken,
                 _trades[i].sendQuantity,
                 _trades[i].receiveToken,
-                _trades[i].minReceiveQuantity,
+                _trades[i].receiveQuantity,
                 _trades[i].data
             );
 
             // ZeroEx (for example) throws custom errors which slip through OpenZeppelin's
             // functionCallWithValue error management and surface here as `bytes`. These should be
             // decode-able off-chain given enough context about protocol targeted by the adapter.
-            try _manager(_setToken).interactManager(address(tradeModule), callData) {}
-            catch Error(string memory _err) {
-                emit StringTradeFailed(address(_setToken), i, _err);
-            } catch (bytes memory _err) {
-                emit BytesTradeFailed(address(_setToken), i, _err);
+            try manager.interactManager(address(tradeModule), callData) {}
+            catch Error(string memory reason) {
+                emit StringTradeFailed(address(_setToken), i, reason);
+            } catch (bytes memory lowLevelData) {
+                emit BytesTradeFailed(address(_setToken), i, lowLevelData);
             }
         }
     }
@@ -197,7 +188,7 @@ contract BatchTradeExtension is BaseGlobalExtension {
      * @param _delegatedManager     Instance of the DelegatedManager to initialize the TradeModule for
      */
     function _initializeModule(ISetToken _setToken, IDelegatedManager _delegatedManager) internal {
-        bytes memory callData = abi.encodeWithSignature("initialize(address)", _setToken);
+        bytes memory callData = abi.encodeWithSelector(ITradeModule.initialize.selector, _setToken);
         _invokeManager(_delegatedManager, address(tradeModule), callData);
     }
 }

--- a/contracts/extensions/BatchTradeExtension.sol
+++ b/contracts/extensions/BatchTradeExtension.sol
@@ -56,13 +56,25 @@ contract BatchTradeExtension is BaseGlobalExtension {
     event StringTradeFailed(
         address indexed _setToken,       // Address of the SetToken which the failed trade targeted
         uint256 indexed _index,          // Index of trade that failed in _trades parameter of batchTrade call
-        string _reason                   // String reason for the trade failure
+        string _reason,                  // String reason for the trade failure
+        string exchangeName,             // Human readable name of the exchange in the integrations registry
+        address sendToken,               // Address of the token to be sent to the exchange
+        uint256 sendQuantity,            // Max units of `sendToken` sent to the exchange
+        address receiveToken,            // Address of the token that will be received from the exchange
+        uint256 receiveQuantity,         // Min units of `receiveToken` to be received from the exchange
+        bytes data                       // Arbitrary bytes to be used to construct trade call data
     );
 
     event BytesTradeFailed(
         address indexed _setToken,       // Address of the SetToken which the failed trade targeted
         uint256 indexed _index,          // Index of trade that failed in _trades parameter of batchTrade call
-        bytes _lowLevelData              // Bytes low level data reason for the trade failure
+        bytes _lowLevelData,             // Bytes low level data reason for the trade failure
+        string exchangeName,             // Human readable name of the exchange in the integrations registry
+        address sendToken,               // Address of the token to be sent to the exchange
+        uint256 sendQuantity,            // Max units of `sendToken` sent to the exchange
+        address receiveToken,            // Address of the token that will be received from the exchange
+        uint256 receiveQuantity,         // Min units of `receiveToken` to be received from the exchange
+        bytes data                       // Arbitrary bytes to be used to construct trade call data
     );
 
     /* ============ State Variables ============ */
@@ -172,9 +184,29 @@ contract BatchTradeExtension is BaseGlobalExtension {
             // decode-able off-chain given enough context about protocol targeted by the adapter.
             try manager.interactManager(address(tradeModule), callData) {}
             catch Error(string memory reason) {
-                emit StringTradeFailed(address(_setToken), i, reason);
+                emit StringTradeFailed(
+                    address(_setToken),
+                    i,
+                    reason,
+                    _trades[i].exchangeName,
+                    _trades[i].sendToken,
+                    _trades[i].sendQuantity,
+                    _trades[i].receiveToken,
+                    _trades[i].receiveQuantity,
+                    _trades[i].data
+                );
             } catch (bytes memory lowLevelData) {
-                emit BytesTradeFailed(address(_setToken), i, lowLevelData);
+                emit BytesTradeFailed(
+                    address(_setToken),
+                    i,
+                    lowLevelData,
+                    _trades[i].exchangeName,
+                    _trades[i].sendToken,
+                    _trades[i].sendQuantity,
+                    _trades[i].receiveToken,
+                    _trades[i].receiveQuantity,
+                    _trades[i].data
+                );
             }
         }
     }

--- a/contracts/extensions/BatchTradeExtension.sol
+++ b/contracts/extensions/BatchTradeExtension.sol
@@ -50,8 +50,13 @@ contract BatchTradeExtension is BaseGlobalExtension {
 
     /* ============ Events ============ */
 
-    event IntegrationAdded(string _integrationName);      // String name of TradeModule exchange integration to allow
-    event IntegrationRemoved(string _integrationName);    // String name of TradeModule exchange integration to disallow
+    event IntegrationAdded(
+        string _integrationName          // String name of TradeModule exchange integration to allow
+    );
+
+    event IntegrationRemoved(
+        string _integrationName          // String name of TradeModule exchange integration to disallow
+    );
 
     event BatchTradeExtensionInitialized(
         address indexed _setToken,                 // Address of the SetToken which had BatchTradeExtension initialized on their manager
@@ -62,24 +67,14 @@ contract BatchTradeExtension is BaseGlobalExtension {
         address indexed _setToken,       // Address of the SetToken which the failed trade targeted
         uint256 indexed _index,          // Index of trade that failed in _trades parameter of batchTrade call
         string _reason,                  // String reason for the trade failure
-        string exchangeName,             // Human readable name of the exchange in the integrations registry
-        address sendToken,               // Address of the token to be sent to the exchange
-        uint256 sendQuantity,            // Max units of `sendToken` sent to the exchange
-        address receiveToken,            // Address of the token that will be received from the exchange
-        uint256 receiveQuantity,         // Min units of `receiveToken` to be received from the exchange
-        bytes data                       // Arbitrary bytes to be used to construct trade call data
+        TradeInfo _tradeInfo             // Input TradeInfo of the failed trade
     );
 
     event BytesTradeFailed(
         address indexed _setToken,       // Address of the SetToken which the failed trade targeted
         uint256 indexed _index,          // Index of trade that failed in _trades parameter of batchTrade call
         bytes _lowLevelData,             // Bytes low level data reason for the trade failure
-        string exchangeName,             // Human readable name of the exchange in the integrations registry
-        address sendToken,               // Address of the token to be sent to the exchange
-        uint256 sendQuantity,            // Max units of `sendToken` sent to the exchange
-        address receiveToken,            // Address of the token that will be received from the exchange
-        uint256 receiveQuantity,         // Min units of `receiveToken` to be received from the exchange
-        bytes data                       // Arbitrary bytes to be used to construct trade call data
+        TradeInfo _tradeInfo             // Input TradeInfo of the failed trade
     );
 
     /* ============ State Variables ============ */
@@ -92,6 +87,16 @@ contract BatchTradeExtension is BaseGlobalExtension {
 
     // Mapping to check whether string is allowed TradeModule exchange integration
     mapping(string => bool) public isIntegration;
+
+    /* ============ Modifiers ============ */
+
+    /**
+     * Throws if the sender is not the ManagerCore contract owner
+     */
+    modifier onlyManagerCoreOwner() {
+        require(msg.sender == managerCore.owner(), "Caller must be ManagerCore owner");
+        _;
+    }
 
     /* ============ Constructor ============ */
 
@@ -122,13 +127,11 @@ contract BatchTradeExtension is BaseGlobalExtension {
     /* ============ External Functions ============ */
 
     /**
-     * PRIVILEGED GOVERNANCE FUNCTION. Allows governance to add allowed TradeModule exchange integrations
+     * MANAGER OWNER ONLY. Allows manager owner to add allowed TradeModule exchange integrations
      *
      * @param _integrations     List of TradeModule exchange integrations to allow
      */
-    function addIntegrations(string[] memory _integrations) external {
-        require(msg.sender == managerCore.owner(), "Caller must be ManagerCore owner");
-
+    function addIntegrations(string[] memory _integrations) external onlyManagerCoreOwner {
         uint256 integrationsLength = _integrations.length;
         for (uint256 i = 0; i < integrationsLength; i++) {
             require(!isIntegration[_integrations[i]], "Integration already exists");
@@ -140,13 +143,11 @@ contract BatchTradeExtension is BaseGlobalExtension {
     }
 
     /**
-     * PRIVILEGED GOVERNANCE FUNCTION. Allows governance to remove allowed TradeModule exchange integrations
+     * MANAGER OWNER ONLY. Allows manager owner to remove allowed TradeModule exchange integrations
      *
      * @param _integrations     List of TradeModule exchange integrations to disallow
      */
-    function removeIntegrations(string[] memory _integrations) external {
-        require(msg.sender == managerCore.owner(), "Caller must be ManagerCore owner");
-
+    function removeIntegrations(string[] memory _integrations) external onlyManagerCoreOwner {
         uint256 integrationsLength = _integrations.length;
         for (uint256 i = 0; i < integrationsLength; i++) {
             require(isIntegration[_integrations[i]], "Integration does not exist");
@@ -246,24 +247,14 @@ contract BatchTradeExtension is BaseGlobalExtension {
                     address(_setToken),
                     i,
                     reason,
-                    _trades[i].exchangeName,
-                    _trades[i].sendToken,
-                    _trades[i].sendQuantity,
-                    _trades[i].receiveToken,
-                    _trades[i].receiveQuantity,
-                    _trades[i].data
+                    _trades[i]
                 );
             } catch (bytes memory lowLevelData) {
                 emit BytesTradeFailed(
                     address(_setToken),
                     i,
                     lowLevelData,
-                    _trades[i].exchangeName,
-                    _trades[i].sendToken,
-                    _trades[i].sendQuantity,
-                    _trades[i].receiveToken,
-                    _trades[i].receiveQuantity,
-                    _trades[i].data
+                    _trades[i]
                 );
             }
         }

--- a/contracts/interfaces/IManagerCore.sol
+++ b/contracts/interfaces/IManagerCore.sol
@@ -22,4 +22,5 @@ interface IManagerCore {
     function isExtension(address _extension) external view returns(bool);
     function isFactory(address _factory) external view returns(bool);
     function isManager(address _manager) external view returns(bool);
+    function owner() external view returns(address);
 }

--- a/test/extensions/batchTradeExtension.spec.ts
+++ b/test/extensions/batchTradeExtension.spec.ts
@@ -700,12 +700,14 @@ describe("BatchTradeExtension", () => {
           setToken.address,
           1,
           "Insufficient funds in exchange",
-          tradeAdapterName,
-          setV2Setup.dai.address,
-          ether(0.4),
-          setV2Setup.wbtc.address,
-          ether(2),
-          EMPTY_BYTES
+          [
+            tradeAdapterName,
+            setV2Setup.dai.address,
+            ether(0.4),
+            setV2Setup.wbtc.address,
+            ether(2),
+            EMPTY_BYTES
+          ]
         );
       });
     });
@@ -754,12 +756,14 @@ describe("BatchTradeExtension", () => {
           setToken.address,
           1,
           expectedByteError,
-          tradeAdapterName,
-          setV2Setup.dai.address,
-          ether(0.4),
-          setV2Setup.wbtc.address,
-          BigNumber.from(1),
-          EMPTY_BYTES
+          [
+            tradeAdapterName,
+            setV2Setup.dai.address,
+            ether(0.4),
+            setV2Setup.wbtc.address,
+            BigNumber.from(1),
+            EMPTY_BYTES
+          ]
         );
       });
     });

--- a/test/extensions/batchTradeExtension.spec.ts
+++ b/test/extensions/batchTradeExtension.spec.ts
@@ -26,7 +26,7 @@ import { ContractTransaction } from "ethers";
 
 const expect = getWaffleExpect();
 
-describe("BatchTradeExtension", () => {
+describe.only("BatchTradeExtension", () => {
   let owner: Account;
   let methodologist: Account;
   let operator: Account;
@@ -552,11 +552,17 @@ describe("BatchTradeExtension", () => {
         expect(oldReceiveTokenTwoBalance).to.eq(actualNewReceiveTokenTwoBalance);
       });
 
-      it("should emit the correct TradeFailed event", async () => {
+      it("should emit the correct StringTradeFailed event", async () => {
         await expect(subject()).to.emit(batchTradeExtension, "StringTradeFailed").withArgs(
           setToken.address,
           1,
-          "Insufficient funds in exchange"
+          "Insufficient funds in exchange",
+          tradeAdapterName,
+          setV2Setup.dai.address,
+          ether(0.4),
+          setV2Setup.wbtc.address,
+          ether(2),
+          EMPTY_BYTES
         );
       });
     });
@@ -604,7 +610,13 @@ describe("BatchTradeExtension", () => {
         await expect(subject()).to.emit(batchTradeExtension, "BytesTradeFailed").withArgs(
           setToken.address,
           1,
-          expectedByteError
+          expectedByteError,
+          tradeAdapterName,
+          setV2Setup.dai.address,
+          ether(0.4),
+          setV2Setup.wbtc.address,
+          BigNumber.from(1),
+          EMPTY_BYTES
         );
       });
     });

--- a/test/extensions/batchTradeExtension.spec.ts
+++ b/test/extensions/batchTradeExtension.spec.ts
@@ -190,7 +190,7 @@ describe("BatchTradeExtension", () => {
       });
 
       it("should revert", async () => {
-        await expect(subject()).to.be.revertedWith("Extension must be initialized");
+        await expect(subject()).to.be.revertedWith("Must be initialized extension");
       });
     });
 
@@ -201,7 +201,7 @@ describe("BatchTradeExtension", () => {
       });
 
       it("should revert", async () => {
-        await expect(subject()).to.be.revertedWith("Extension must be initialized");
+        await expect(subject()).to.be.revertedWith("Must be initialized extension");
       });
     });
 
@@ -471,7 +471,7 @@ describe("BatchTradeExtension", () => {
         sendToken: setV2Setup.dai.address,
         sendQuantity: ether(0.6),
         receiveToken: setV2Setup.weth.address,
-        minReceiveQuantity: ether(0),
+        receiveQuantity: ether(0),
         data: EMPTY_BYTES
       } as TradeInfo;
       subjectTradeTwo = {
@@ -479,7 +479,7 @@ describe("BatchTradeExtension", () => {
         sendToken: setV2Setup.dai.address,
         sendQuantity: ether(0.4),
         receiveToken: setV2Setup.wbtc.address,
-        minReceiveQuantity: ether(0),
+        receiveQuantity: ether(0),
         data: EMPTY_BYTES
       } as TradeInfo;
       subjectTrades = [subjectTradeOne, subjectTradeTwo];
@@ -528,7 +528,7 @@ describe("BatchTradeExtension", () => {
           sendToken: setV2Setup.dai.address,
           sendQuantity: ether(0.4),
           receiveToken: setV2Setup.wbtc.address,
-          minReceiveQuantity: ether(2),
+          receiveQuantity: ether(2),
           data: EMPTY_BYTES
         } as TradeInfo;
         subjectTrades = [subjectTradeOne, subjectTradeTwo];
@@ -568,7 +568,7 @@ describe("BatchTradeExtension", () => {
           sendToken: setV2Setup.dai.address,
           sendQuantity: ether(0.4),
           receiveToken: setV2Setup.wbtc.address,
-          minReceiveQuantity: BigNumber.from(1),
+          receiveQuantity: BigNumber.from(1),
           data: EMPTY_BYTES
         } as TradeInfo;
         subjectTrades = [subjectTradeOne, subjectTradeTwo];
@@ -616,7 +616,7 @@ describe("BatchTradeExtension", () => {
           sendToken: setV2Setup.dai.address,
           sendQuantity: ether(0.4),
           receiveToken: setV2Setup.usdc.address,
-          minReceiveQuantity: ether(0),
+          receiveQuantity: ether(0),
           data: EMPTY_BYTES
         } as TradeInfo;
         subjectTrades = [subjectTradeOne, subjectTradeTwo];

--- a/test/integration/batchTradeExtensionZeroEx.spec.ts
+++ b/test/integration/batchTradeExtensionZeroEx.spec.ts
@@ -208,7 +208,7 @@ describe("BatchTradeExtension - ZeroExAPITradeAdapter - TradeModule Integration 
           sendToken: tokens.dai.address,
           sendQuantity: daiPositionUnit,
           receiveToken: tokens.wbtc.address,
-          minReceiveQuantity: ether(0),
+          receiveQuantity: ether(0),
           data: daiQuote.data
         } as TradeInfo;
 
@@ -217,7 +217,7 @@ describe("BatchTradeExtension - ZeroExAPITradeAdapter - TradeModule Integration 
           sendToken: tokens.weth.address,
           sendQuantity: wethPositionUnit,
           receiveToken: tokens.wbtc.address,
-          minReceiveQuantity: ether(0),
+          receiveQuantity: ether(0),
           data: wethQuote.data
         } as TradeInfo;
 
@@ -282,7 +282,7 @@ describe("BatchTradeExtension - ZeroExAPITradeAdapter - TradeModule Integration 
           sendToken: tokens.dai.address,
           sendQuantity: daiPositionUnit,
           receiveToken: tokens.wbtc.address,
-          minReceiveQuantity: ether(0),
+          receiveQuantity: ether(0),
           data: daiQuote.data
         } as TradeInfo;
 
@@ -340,7 +340,7 @@ describe("BatchTradeExtension - ZeroExAPITradeAdapter - TradeModule Integration 
           sendToken: tokens.dai.address,
           sendQuantity: daiPositionUnit,
           receiveToken: tokens.wbtc.address,
-          minReceiveQuantity: ether(0),
+          receiveQuantity: ether(0),
           data: daiQuote.data
         } as TradeInfo;
 

--- a/test/integration/batchTradeExtensionZeroEx.spec.ts
+++ b/test/integration/batchTradeExtensionZeroEx.spec.ts
@@ -142,7 +142,8 @@ describe("BatchTradeExtension - ZeroExAPITradeAdapter - TradeModule Integration 
 
     batchTradeExtension = await deployer.globalExtensions.deployBatchTradeExtension(
       managerCore.address,
-      tradeModule.address
+      tradeModule.address,
+      [zeroExApiAdapterName]
     );
 
     delegatedManager = await deployer.manager.deployDelegatedManager(

--- a/utils/deploys/deployGlobalExtensions.ts
+++ b/utils/deploys/deployGlobalExtensions.ts
@@ -21,11 +21,13 @@ export default class DeployGlobalExtensions {
 
   public async deployBatchTradeExtension(
     managerCore: Address,
-    tradeModule: Address
+    tradeModule: Address,
+    integrations: string[]
   ): Promise<BatchTradeExtension> {
     return await new BatchTradeExtension__factory(this._deployerSigner).deploy(
       managerCore,
       tradeModule,
+      integrations
     );
   }
 

--- a/utils/types.ts
+++ b/utils/types.ts
@@ -126,7 +126,7 @@ export interface TradeInfo {
   sendToken: Address;
   sendQuantity: BigNumber;
   receiveToken: Address;
-  minReceiveQuantity: BigNumber;
+  receiveQuantity: BigNumber;
   data: Bytes;
 }
 


### PR DESCRIPTION
Major changes
- Add list of approved `TradeModule` adapter integrations to the `BatchTradeExtension`

Events
- Add trade arguments to `StringTradeFailed` and `BytesTradeFailed` events

Removal of repeated checks
- Remove check for if the extension is initialized in `initializeModule()`
- Remove check for if the extension is pending in `initializeExtension()`
- Remove check for if the extension is pending in `initializeModuleAndExtension()`

Gas optimizations
- Use `abi.encodeWithSelector` instead of `abi.encodeWithSignature`
- Read `manager` and length of `_trades` before loop in `batchTrade()`
    - Remove `onlyAllowedAssets` modifier and perform check in loop of `batchTrade`

Javadoc fixes
- Reword contract description
- `TradeInfo.sendQuantity` and `TradeInfo.receiveQuantity` clarification
- Add javadocs for `BatchTradeExtensionInitialized` event parameters
- Use more descriptive parameter name in `BytesTradeFailed` event, reword `StringTradeFailed` and `BytesTradeFailed` javadoc
- Add javadoc for constructor
- Fix javadoc for `initializeModuleAndExtension()`
- Reword javadoc for `batchTrade()`

Notes
- Removal of repeated checks can be performed in other global extensions (`IssuanceExtension`, `StreamingFeeSplitExtension`, `TradeExtension`)
- Tests for repeated checks are left and check for reverts with error messages from the `DelegatedManager`