### PR TITLE
fix(DeltaNeutralBasisTradingStrategyExtension): Fix for accounting for precision applied by PERP protocol on their US…

### DIFF
--- a/contracts/extensions/DeltaNeutralBasisTradingStrategyExtension.sol
+++ b/contracts/extensions/DeltaNeutralBasisTradingStrategyExtension.sol
@@ -1168,7 +1168,9 @@ contract DeltaNeutralBasisTradingStrategyExtension is BaseExtension {
 
         // Check that there is zero position unit of USDC of collateral value. Allows to neglect dust amounts.
         require(
-            engageInfo.accountInfo.collateralBalance.preciseDiv(engageInfo.setTotalSupply.toInt256()) == 0,
+            engageInfo.accountInfo.collateralBalance
+                .fromPreciseUnitToDecimals(collateralDecimals)
+                .preciseDiv(engageInfo.setTotalSupply.toInt256()) == 0,
             "PerpV2 collateral balance must be 0"
         );
 

--- a/contracts/extensions/DeltaNeutralBasisTradingStrategyExtension.sol
+++ b/contracts/extensions/DeltaNeutralBasisTradingStrategyExtension.sol
@@ -1169,7 +1169,7 @@ contract DeltaNeutralBasisTradingStrategyExtension is BaseExtension {
         // Check that there is zero position unit of USDC of collateral value. Allows to neglect dust amounts.
         require(
             engageInfo.accountInfo.collateralBalance
-                .fromPreciseUnitToDecimals(collateralDecimals)
+                .fromPreciseUnitToDecimals(collateralDecimals)              // PERP returns 18 decimal number, must convert for logic to work
                 .preciseDiv(engageInfo.setTotalSupply.toInt256()) == 0,
             "PerpV2 collateral balance must be 0"
         );

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@setprotocol/set-v2-strategies",
-  "version": "0.0.12",
+  "version": "0.0.13",
   "description": "",
   "main": "dist",
   "types": "dist/types",

--- a/test/extensions/deltaNeutralBasisTradingStrategyExtension.spec.ts
+++ b/test/extensions/deltaNeutralBasisTradingStrategyExtension.spec.ts
@@ -940,7 +940,7 @@ describe("DeltaNeutralBasisTradingStrategyExtension", () => {
 
           await leverageStrategyExtension.withdraw(collateralUnits);
           // Left out collateral balance (in USDC decimals) = 60; Total supply = 100
-          // 60e18/100e18 < 1; Hence the re-engage should not revert
+          // 60e12/1e12 = 60, 60*1e18/100e18 < 1 (rounds to 0); Hence the re-engage should not revert!
         });
 
         it("should not revert", async () => {

--- a/test/extensions/deltaNeutralBasisTradingStrategyExtension.spec.ts
+++ b/test/extensions/deltaNeutralBasisTradingStrategyExtension.spec.ts
@@ -931,7 +931,7 @@ describe("DeltaNeutralBasisTradingStrategyExtension", () => {
 
       describe("when collateral balance is non-zero", async () => {
         beforeEach(async () => {
-          await leverageStrategyExtension.deposit(BigNumber.from(1));
+          await leverageStrategyExtension.deposit(usdc(1));
         });
 
         it("should revert", async () => {

--- a/test/extensions/deltaNeutralBasisTradingStrategyExtension.spec.ts
+++ b/test/extensions/deltaNeutralBasisTradingStrategyExtension.spec.ts
@@ -919,9 +919,19 @@ describe("DeltaNeutralBasisTradingStrategyExtension", () => {
         });
       });
 
+      describe("when collateral balance is non-zero but less than a position unit (must account for PERP decimal adjustment)", async () => {
+        beforeEach(async () => {
+          // Set up for test case where less than 100 USDC units are left
+        });
+
+        it("should not revert", async () => {
+          await expect(subject()).to.not.be.reverted;
+        });
+      });
+
       describe("when collateral balance is non-zero", async () => {
         beforeEach(async () => {
-          await leverageStrategyExtension.deposit(usdc(1));
+          await leverageStrategyExtension.deposit(BigNumber.from(1));
         });
 
         it("should revert", async () => {

--- a/test/extensions/deltaNeutralBasisTradingStrategyExtension.spec.ts
+++ b/test/extensions/deltaNeutralBasisTradingStrategyExtension.spec.ts
@@ -919,9 +919,22 @@ describe("DeltaNeutralBasisTradingStrategyExtension", () => {
         });
       });
 
-      describe("when collateral balance is non-zero but less than a position unit (must account for PERP decimal adjustment)", async () => {
+      describe.only("when collateral balance is non-zero but less than a position unit (must account for PERP decimal adjustment)", async () => {
         beforeEach(async () => {
-          // Set up for test case where less than 100 USDC units are left
+          await subject();
+
+          await perpV2Setup.setBaseTokenOraclePrice(perpV2Setup.vETH, usdc(950));
+          await perpV2PriceFeedMock.setPrice(BigNumber.from(950).mul(10 ** 8));
+
+          await increaseTimeAsync(ONE_DAY_IN_SECONDS);
+
+          await leverageStrategyExtension.disengage();
+
+          await leverageStrategyExtension.withdraw(BigNumber.from(99698790));
+
+          const collateralUnits = (await perpBasisTradingModule.getAccountInfo(setToken.address)).collateralBalance;
+          console.log(collateralUnits.toString());
+
         });
 
         it("should not revert", async () => {


### PR DESCRIPTION
### Bug Analysis
[Triage Basis Trading: Delta Neutrality Deviation Spike](https://docs.google.com/document/d/1_P38X6SvRq4WZ9Ys3npRLnhrxY5pM1s9ne9KWj4sq90/edit)

When engaging a Set into a delta-neutral basis trading position we check to make sure that there is not already enough collateral in the Set to be able to make a position out of it. For example if there is one USDC (1000000 in the Set and we have 10 Sets issued, we would not allow `engage` to be called since 1000000/10 = 100000 which means we could make a position unit out of it. We would need to have issue 1 million +1 Sets to be able to call engage since 1000000/1000001 = 0 (in Solidity world).

However, Perpetual Protocol applies precision to all of their USDC balances in order to make them 18 decimal tokens. So even if you have only one _unit_ of USDC left, it is represented to external contracts as 1000000000000. We have now run into an issue where `1398357137794738030184` Sets have been issued (~1398 Sets) and there is 705 units of USDC left (represented as `705000000000000`) in Perpetual Protocol. In this case we want the `engage` to go ahead but it won't because `705000000000000/1398 >> 0`. Hence we need to undo the precision applied by Perpetual Protocol so that we are making the correct calculation: `705/1398 = 0`.

**Erroring Code:**
```
        require(
            engageInfo.accountInfo.collateralBalance.preciseDiv(engageInfo.setTotalSupply.toInt256()) == 0,
            "PerpV2 collateral balance must be 0"
        );
```
        
### Requirement
Update calculations to
1. Ensure that added USDC precision is removed

### Solution
Update the code to ensure we are removing the precision added by Perpetual Protocol.

```
        require(
            engageInfo.accountInfo.collateralBalance
                .fromPreciseUnitToDecimals(collateralDecimals)
                .preciseDiv(engageInfo.setTotalSupply.toInt256()) == 0,
            "PerpV2 collateral balance must be 0"
        );
```


### Tasks
- [x] Implement Fix
- [x] Add new test case to ensure engage can go through when USDC units < setTotalSupply (in whole Sets not preciseUnits)
