### PR TITLE
fix(DeltaNeutralBasisTradingStrategy): Fix selling more than available spot notional amount

### DIFF
--- a/contracts/extensions/DeltaNeutralBasisTradingStrategyExtension.sol
+++ b/contracts/extensions/DeltaNeutralBasisTradingStrategyExtension.sol
@@ -1121,14 +1121,14 @@ contract DeltaNeutralBasisTradingStrategyExtension is BaseExtension {
         int256 denominator = _leverageInfo.currentLeverageRatio.preciseMul(PreciseUnitMath.preciseUnitInt().sub(_newLeverageRatio));
         int256 totalRebalanceNotional = leverageRatioDifference.preciseMul(_leverageInfo.action.baseBalance).preciseDiv(denominator);
 
-        if (totalRebalanceNotional > 0) {
-            // When decreasing our short position on PerpV2, we would also be selling spot position to decrease spot exposure and
-            // maintain delta-neutrality. `spotNotional` is the max amount of spot we can sell and totalRebalanceNotional should
-            // be <= spotNotional.
-            uint256 spotUnits = strategy.setToken.getDefaultPositionRealUnit(strategy.spotAssetAddress).toUint256();
-            uint256 spotNotional = spotUnits.preciseMul(_leverageInfo.action.setTotalSupply);
-            totalRebalanceNotional = Math.min(totalRebalanceNotional.abs(), spotNotional).toInt256();
-        }
+        // if (totalRebalanceNotional > 0) {
+        //     // When decreasing our short position on PerpV2, we would also be selling spot position to decrease spot exposure and
+        //     // maintain delta-neutrality. `spotNotional` is the max amount of spot we can sell and totalRebalanceNotional should
+        //     // be <= spotNotional.
+        //     uint256 spotUnits = strategy.setToken.getDefaultPositionRealUnit(strategy.spotAssetAddress).toUint256();
+        //     uint256 spotNotional = spotUnits.preciseMul(_leverageInfo.action.setTotalSupply);
+        //     totalRebalanceNotional = Math.min(totalRebalanceNotional.abs(), spotNotional).toInt256();
+        // }
 
         uint256 chunkRebalanceNotionalAbs = Math.min(totalRebalanceNotional.abs(), _leverageInfo.twapMaxTradeSize);
         return (

--- a/contracts/extensions/DeltaNeutralBasisTradingStrategyExtension.sol
+++ b/contracts/extensions/DeltaNeutralBasisTradingStrategyExtension.sol
@@ -1121,14 +1121,14 @@ contract DeltaNeutralBasisTradingStrategyExtension is BaseExtension {
         int256 denominator = _leverageInfo.currentLeverageRatio.preciseMul(PreciseUnitMath.preciseUnitInt().sub(_newLeverageRatio));
         int256 totalRebalanceNotional = leverageRatioDifference.preciseMul(_leverageInfo.action.baseBalance).preciseDiv(denominator);
 
-        // if (totalRebalanceNotional > 0) {
-        //     // When decreasing our short position on PerpV2, we would also be selling spot position to decrease spot exposure and
-        //     // maintain delta-neutrality. `spotNotional` is the max amount of spot we can sell and totalRebalanceNotional should
-        //     // be <= spotNotional.
-        //     uint256 spotUnits = strategy.setToken.getDefaultPositionRealUnit(strategy.spotAssetAddress).toUint256();
-        //     uint256 spotNotional = spotUnits.preciseMul(_leverageInfo.action.setTotalSupply);
-        //     totalRebalanceNotional = Math.min(totalRebalanceNotional.abs(), spotNotional).toInt256();
-        // }
+        if (totalRebalanceNotional > 0) {
+            // When decreasing our short position on PerpV2, we would also be selling spot position to decrease spot exposure and
+            // maintain delta-neutrality. `spotNotional` is the max amount of spot we can sell and totalRebalanceNotional should
+            // be <= spotNotional.
+            uint256 spotUnits = strategy.setToken.getDefaultPositionRealUnit(strategy.spotAssetAddress).toUint256();
+            uint256 spotNotional = spotUnits.preciseMul(_leverageInfo.action.setTotalSupply);
+            totalRebalanceNotional = Math.min(totalRebalanceNotional.abs(), spotNotional).toInt256();
+        }
 
         uint256 chunkRebalanceNotionalAbs = Math.min(totalRebalanceNotional.abs(), _leverageInfo.twapMaxTradeSize);
         return (

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@setprotocol/set-v2-strategies",
-  "version": "0.0.13-basis.0",
+  "version": "0.0.14",
   "description": "",
   "main": "dist",
   "types": "dist/types",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@setprotocol/set-v2-strategies",
-  "version": "0.0.13",
+  "version": "0.0.13-basis.0",
   "description": "",
   "main": "dist",
   "types": "dist/types",


### PR DESCRIPTION
### Problem
This disengage [transaction](https://optimistic.etherscan.io/tx/0x12eb72731159328ddeb4129e987f3abbd8c1cb50207e99aa545f3eaf2e010302) fails when we close our entire short vETH position during disengage and try to sell an equal amount of WETH. But since, vETH position unit = `2571061763936282` and WETH position unit = `2571061763936280`, we are trying to sell more than what we have.

### Fix
Refactor `_calculateChunRebalanceNotional` to also take into account the current WETH notional amount while deciding how much vETH short position to close. We should not sell more than what we have in the Set. 

With this fix, in the above case we would end up selling `2571061763936280` unis of WETH and close an equal amount of short position, thus maintaining delta neutrality.

### Deployment

Patched strategy contract: [0x5501Cf014E6d72701e6D1447E12adb16aF37af26](https://optimistic.etherscan.io/address/0x5501Cf014E6d72701e6D1447E12adb16aF37af26)
Successful disengage transaction : [0xc92979713d1f70bcaa5a2aec140eb439363b97e4b4d81fcc9510441452a2b644](https://optimistic.etherscan.io/tx/0xc92979713d1f70bcaa5a2aec140eb439363b97e4b4d81fcc9510441452a2b644)